### PR TITLE
Audit | 5.1, 5.8, 6.5 OperationStorage and OperationExecutor fixes

### DIFF
--- a/contracts/core/OperationStorage.sol
+++ b/contracts/core/OperationStorage.sol
@@ -40,7 +40,7 @@ contract OperationStorage {
     return returnValues.length;
   }
 
-  function finalize() external {
+  function clearStorage() external {
     delete action;
     delete actions;
     delete returnValues;

--- a/contracts/core/OperationsRegistry.sol
+++ b/contracts/core/OperationsRegistry.sol
@@ -2,14 +2,22 @@ pragma solidity ^0.8.5;
 
 import { Operation } from "./types/Common.sol";
 
+struct StoredOperation {
+  bytes32[] actions;
+  string name;
+}
+
 contract OperationsRegistry {
-  mapping(string => bytes32[]) private operations;
+  mapping(string => StoredOperation) private operations;
 
   function addOperation(string memory name, bytes32[] memory actions) external {
-    operations[name] = actions;
+    operations[name] = StoredOperation(actions, name);
   }
 
   function getOperation(string memory name) external view returns (bytes32[] memory actions) {
-    actions = operations[name];
+    if(keccak256(bytes(operations[name].name)) == keccak256(bytes(""))) {
+      revert("Operation doesn't exist");
+    }
+    actions = operations[name].actions;
   }
 }


### PR DESCRIPTION
**5.1 OperationStorage Can Be Polluted**
Fix:
- Ensure storage is empty before the execution. `finalize` function is changed to `clearStorage` and executed also before iterating actions.
- 
**5.8 Visibility of aggregate Function**
Fix:
- Visibility of `aggregate` is changed to `internal` and callback from storage is executed via `callbackAggregate` which is public but restricts execution only by OperationExecutor itself.

**6.5 OperationRegistry: No Entry, No Checks**

- `getOperation` in OperationRegistry is reverting on non-existing operation instead of returning empty array (which results in skipping checks). Custom operation with empty actions has to be explicitly added to OperationRegistry and used on FE.

 