### PR TITLE
Audit | 5.1 OperationStorage Can Be Polluted

### DIFF
--- a/contracts/core/OperationExecutor.sol
+++ b/contracts/core/OperationExecutor.sol
@@ -39,9 +39,10 @@ contract OperationExecutor is IERC3156FlashBorrower {
     );
     opStorage.setOperationActions(opRegistry.getOperation(operationName));
 
+    opStorage.clearStorage();
     aggregate(calls);
+    opStorage.clearStorage();
 
-    opStorage.finalize();
     emit Operation(operationName, calls);
   }
 

--- a/contracts/core/OperationStorage.sol
+++ b/contracts/core/OperationStorage.sol
@@ -40,7 +40,7 @@ contract OperationStorage {
     return returnValues.length;
   }
 
-  function finalize() external {
+  function clearStorage() external {
     delete action;
     delete actions;
     delete returnValues;


### PR DESCRIPTION
**5.1 OperationStorage Can Be Polluted**
Fix: Ensure storage is empty before the execution. finalize function is changed to clearStorage and executed also before iterating actions.