### PR TITLE
Audit | 5.6 No Access Control on onFlashLoan

### DIFF
--- a/contracts/core/OperationExecutor.sol
+++ b/contracts/core/OperationExecutor.sol
@@ -70,6 +70,9 @@ contract OperationExecutor is IERC3156FlashBorrower {
     bytes calldata data
   ) external override returns (bytes32) {
     address lender = registry.getRegisteredService(FLASH_MINT_MODULE);
+
+    require(msg.sender == lender, "Untrusted flashloan lender");
+    
     FlashloanData memory flData = abi.decode(data, (FlashloanData));
 
     require(amount == flData.amount, "loan-inconsistency");


### PR DESCRIPTION
**5.6 No Access Control on onFlashLoan**

Fix: Added assertion msg.sender == lender