### PR TITLE
Audit | 6.8 Sanity Check in onFlashloan

### DIFF
--- a/contracts/core/OperationExecutor.sol
+++ b/contracts/core/OperationExecutor.sol
@@ -72,7 +72,7 @@ contract OperationExecutor is IERC3156FlashBorrower {
     address lender = registry.getRegisteredService(FLASH_MINT_MODULE);
     FlashloanData memory flData = abi.decode(data, (FlashloanData));
 
-    require(amount == flData.amount, "loan-inconsistency");
+    require(IERC20(asset).balanceOf(address(this)) == flData.amount, "Flashloan inconsistency");
 
     if (flData.dsProxyFlashloan) {
       IERC20(asset).safeTransfer(initiator, flData.amount);


### PR DESCRIPTION
**6.8 Sanity Check in on Flashloan**

Fix: Require is checking requested amount from params with actual token amount in the contract.