### PR TITLE
Audit | 6.7 Receiver of Flashloan

### DIFF
--- a/contracts/actions/common/TakeFlashloan.sol
+++ b/contracts/actions/common/TakeFlashloan.sol
@@ -19,19 +19,21 @@ contract TakeFlashloan is Executable, ProxyPermission {
   function execute(bytes calldata data, uint8[] memory) external payable override {
     FlashloanData memory flData = abi.decode(data, (FlashloanData));
 
+    address operationExecutorAddress = registry.getRegisteredService(OPERATION_EXECUTOR);
+
     if (flData.dsProxyFlashloan) {
-      givePermission(registry.getRegisteredService(OPERATION_EXECUTOR));
+      givePermission(operationExecutorAddress);
     }
 
     IERC3156FlashLender(registry.getRegisteredService(FLASH_MINT_MODULE)).flashLoan(
-      IERC3156FlashBorrower(flData.borrower),
+      IERC3156FlashBorrower(operationExecutorAddress),
       registry.getRegisteredService(DAI),
       flData.amount,
       data
     );
 
     if (flData.dsProxyFlashloan) {
-      removePermission(registry.getRegisteredService(OPERATION_EXECUTOR));
+      removePermission(operationExecutorAddress);
     }
     emit Action(TAKE_FLASH_LOAN_ACTION, bytes32(flData.amount));
   }

--- a/contracts/core/types/Common.sol
+++ b/contracts/core/types/Common.sol
@@ -2,7 +2,6 @@ pragma solidity ^0.8.1;
 
 struct FlashloanData {
   uint256 amount;
-  address borrower;
   bool dsProxyFlashloan;
   Call[] calls;
 }

--- a/helpers/types/actions.ts
+++ b/helpers/types/actions.ts
@@ -8,7 +8,7 @@ export const calldataTypes = {
     bytes withData) swapData`,
     SendToken: `tuple(address asset, address to, uint256 amount)`,
     PullToken: `tuple(address asset, address from, uint256 amount)`,
-    TakeAFlashLoan: `tuple(uint256 amount, address borrower, bool dsProxyFlashloan, (bytes32 targetHash, bytes callData)[] calls)`,
+    TakeAFlashLoan: `tuple(uint256 amount, bool dsProxyFlashloan, (bytes32 targetHash, bytes callData)[] calls)`,
   },
   maker: {
     Open: `tuple(address joinAddress)`,

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -258,7 +258,6 @@ async function main() {
     [
       {
         amount: flashloanAmount.toFixed(0),
-        borrower: operationExecutorAddress,
         calls: [
           pullBorrowedFundsIntoProxy,
           setDaiApprovalOnLendingPool,

--- a/test/aave/OpenStEth.test.ts
+++ b/test/aave/OpenStEth.test.ts
@@ -185,7 +185,6 @@ describe(`Operations | AAVE | ${OPERATION_NAMES.aave.OPEN_POSITION}`, async () =
       [
         {
           amount: flashloanAmount.toFixed(0),
-          borrower: system.common.operationExecutor.address,
           dsProxyFlashloan: true,
           calls: [
             setDaiApprovalOnLendingPool,

--- a/test/common/TakeFlashloan.test.ts
+++ b/test/common/TakeFlashloan.test.ts
@@ -62,7 +62,6 @@ describe('TakeFlashloan Action', () => {
       [
         {
           amount: ensureWeiFormat(AMOUNT),
-          borrower: system.common.operationExecutor.address,
           dsProxyFlashloan: true,
           calls: [sendBackDAI],
         },
@@ -104,7 +103,6 @@ describe('TakeFlashloan Action', () => {
       [
         {
           amount: ensureWeiFormat(AMOUNT),
-          borrower: system.common.operationExecutor.address,
           dsProxyFlashloan: true,
           calls: [sendBackDAI],
         },
@@ -133,7 +131,6 @@ describe('TakeFlashloan Action', () => {
       [
         {
           amount: ensureWeiFormat(AMOUNT),
-          borrower: system.common.operationExecutor.address,
           dsProxyFlashloan: true,
           calls: [],
         },

--- a/test/maker/IncreaseMultipleWithFL.test.ts
+++ b/test/maker/IncreaseMultipleWithFL.test.ts
@@ -238,7 +238,6 @@ describe(`Operations | Maker | ${OPERATION_NAMES.maker.INCREASE_MULTIPLE_WITH_FL
       [
         {
           amount: exchangeData.fromTokenAmount,
-          borrower: system.common.operationExecutor.address,
           dsProxyFlashloan: true,
           calls: [
             swapAction,

--- a/test/maker/IncreaseMultipleWithFLAndDaiAndCollTopup.test.ts
+++ b/test/maker/IncreaseMultipleWithFLAndDaiAndCollTopup.test.ts
@@ -263,7 +263,6 @@ describe(`Operations | Maker | ${OPERATION_NAMES.maker.INCREASE_MULTIPLE_WITH_FL
       [
         {
           amount: exchangeData.fromTokenAmount,
-          borrower: system.common.operationExecutor.address,
           dsProxyFlashloan: true,
           calls: [swapAction, depositBorrowedCollateral, generateDaiToRepayFL, sendBackDAI],
         },

--- a/test/maker/IncreaseMultipleWithFLAutomation.test.ts
+++ b/test/maker/IncreaseMultipleWithFLAutomation.test.ts
@@ -238,7 +238,6 @@ describe(`Operations | Maker | ${OPERATION_NAMES.maker.INCREASE_MULTIPLE_WITH_FL
       [
         {
           amount: exchangeData.fromTokenAmount,
-          borrower: system.common.operationExecutor.address,
           dsProxyFlashloan: true,
           calls: [
             swapAction,
@@ -294,7 +293,6 @@ describe(`Operations | Maker | ${OPERATION_NAMES.maker.INCREASE_MULTIPLE_WITH_FL
       [
         {
           amount: ensureWeiFormat(autoTestAmount),
-          borrower: system.common.operationExecutor.address,
           dsProxyFlashloan: false,
           calls: [generateDaiAutomation],
         },


### PR DESCRIPTION
**6.7 Receiver of Flashloan**

OperationExecutor is the only valid borrower, so there is no need to pass it from frontend.

Fix: `OPERATION_EXECUTOR` address is fetched in TakeFlashloan action and set as a borrower. Borrower removed from action params.