### PR TITLE
Audit | 5.4 Maker Deposit Action Uses Full Balance

### DIFF
--- a/contracts/actions/maker/Deposit.sol
+++ b/contracts/actions/maker/Deposit.sol
@@ -36,10 +36,6 @@ contract MakerDeposit is Executable, UseStore {
   function _deposit(DepositData memory data) internal returns (bytes32) {
     address gem = data.joinAddress.gem();
 
-    if (gem == registry.getRegisteredService(WETH)) {
-      IWETH(gem).deposit{ value: address(this).balance }();
-    }
-
     if (data.amount == type(uint256).max) {
       data.amount = IERC20(gem).balanceOf(address(this));
     }


### PR DESCRIPTION
Wrap Eth functionality is removed from Maker Deposit Action. All operations in tests are using WETH. For Eth support wrapping action needs to be introduced.