### PR TITLE
Audit | 5.2 Sanity Check in on Flashloan

### DIFF
--- a/contracts/core/OperationExecutor.sol
+++ b/contracts/core/OperationExecutor.sol
@@ -83,7 +83,7 @@ contract OperationExecutor is IERC3156FlashBorrower {
     
     FlashloanData memory flData = abi.decode(data, (FlashloanData));
 
-    require(IERC20(asset).balanceOf(address(this)) == flData.amount, "Flashloan inconsistency");
+    require(IERC20(asset).balanceOf(address(this)) >= flData.amount, "Flashloan inconsistency");
 
     if (flData.dsProxyFlashloan) {
       IERC20(asset).safeTransfer(initiator, flData.amount);


### PR DESCRIPTION
Condition for flash loaned amount is changed to `>=` to ensure any tokens present inside the contract before the flash loan won't affect current operation. Any funds sent to OperationExecutor contract shouldn't interfere with operation execution but should be considered as lost.