### PR TITLE
Set default flashloan to one

### DIFF
--- a/packages/oasis-actions/package.json
+++ b/packages/oasis-actions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oasisdex/oasis-actions",
-  "version": "0.0.4-alpha.5",
+  "version": "0.0.4-alpha.7",
   "main": "lib/src/index.js",
   "typings": "lib/src/index.d.ts",
   "scripts": {

--- a/packages/oasis-actions/src/helpers/constants.ts
+++ b/packages/oasis-actions/src/helpers/constants.ts
@@ -81,3 +81,9 @@ export const OPERATION_NAMES = {
     CUSTOM_OPERATION: 'CustomOperation',
   },
 } as const
+
+// If configuring a low LTV, we might not need a flashloan (therefore flashloan == 0), but we still perform
+// the swap because the actions in operation executor pass args to each other referenced via index.
+// 1inch however errors out when trying to swap 0 amount, so we swap some small amount instead.
+// This is that amount.
+export const UNUSED_FLASHLOAN_AMOUNT = ONE

--- a/packages/oasis-actions/src/strategies/aave/adjustStEth.ts
+++ b/packages/oasis-actions/src/strategies/aave/adjustStEth.ts
@@ -18,6 +18,7 @@ interface AdjustStEthArgs {
   slippage: BigNumber
   multiple: BigNumber
 }
+
 interface AdjustStEthDependencies {
   addresses: IncreaseMultipleStEthAddresses | DecreaseMultipleStEthAddresses
   provider: providers.Provider
@@ -136,9 +137,11 @@ export async function adjustStEth(
 
     const borrowEthAmountWei = target.delta.debt.minus(depositEthWei)
 
+    const flashloanAmount = target.delta?.flashloanAmount || ZERO
+
     calls = await operations.aave.increaseMultipleStEth(
       {
-        flashloanAmount: target.delta?.flashloanAmount || ZERO,
+        flashloanAmount: flashloanAmount.eq(ZERO) ? ONE : flashloanAmount,
         borrowAmount: borrowEthAmountWei,
         fee: FEE,
         swapData: swapData.exchangeCalldata,

--- a/packages/oasis-actions/src/strategies/aave/adjustStEth.ts
+++ b/packages/oasis-actions/src/strategies/aave/adjustStEth.ts
@@ -6,7 +6,7 @@ import chainlinkPriceFeedABI from '../../abi/chainlinkPriceFeedABI.json'
 import { amountFromWei } from '../../helpers'
 import { IBasePosition, IPosition, Position } from '../../helpers/calculations/Position'
 import { RiskRatio } from '../../helpers/calculations/RiskRatio'
-import { ONE, ZERO } from '../../helpers/constants'
+import { UNUSED_FLASHLOAN_AMOUNT, ZERO } from '../../helpers/constants'
 import * as operations from '../../operations'
 import { DecreaseMultipleStEthAddresses } from '../../operations/aave/decreaseMultipleStEth'
 import type { IncreaseMultipleStEthAddresses } from '../../operations/aave/increaseMultipleStEth'
@@ -141,7 +141,7 @@ export async function adjustStEth(
 
     calls = await operations.aave.increaseMultipleStEth(
       {
-        flashloanAmount: flashloanAmount.eq(ZERO) ? ONE : flashloanAmount,
+        flashloanAmount: flashloanAmount.eq(ZERO) ? UNUSED_FLASHLOAN_AMOUNT : flashloanAmount,
         borrowAmount: borrowEthAmountWei,
         fee: FEE,
         swapData: swapData.exchangeCalldata,
@@ -182,8 +182,7 @@ export async function adjustStEth(
 
     calls = await operations.aave.decreaseMultipleStEth(
       {
-        //TODO: hacky fix for using flashloan. Needs conditional in operation itself
-        flashloanAmount: absFlashloanAmount.eq(ZERO) ? ONE : absFlashloanAmount,
+        flashloanAmount: absFlashloanAmount.eq(ZERO) ? UNUSED_FLASHLOAN_AMOUNT : absFlashloanAmount,
         withdrawAmount: withdrawStEthAmountWei,
         fee: FEE,
         swapData: swapData.exchangeCalldata,

--- a/packages/oasis-actions/src/strategies/aave/openStEth.ts
+++ b/packages/oasis-actions/src/strategies/aave/openStEth.ts
@@ -7,7 +7,7 @@ import chainlinkPriceFeedABI from '../../abi/chainlinkPriceFeedABI.json'
 import { amountFromWei } from '../../helpers'
 import { Position } from '../../helpers/calculations/Position'
 import { RiskRatio } from '../../helpers/calculations/RiskRatio'
-import { ZERO } from '../../helpers/constants'
+import { ONE, ZERO } from '../../helpers/constants'
 import * as operation from '../../operations'
 import type { OpenStEthAddresses } from '../../operations/aave/openStEth'
 import { IStrategy } from '../types/IStrategy'
@@ -136,7 +136,7 @@ export async function openStEth(
 
   const calls = await operation.aave.openStEth(
     {
-      flashloanAmount: target.delta?.flashloanAmount || ZERO,
+      flashloanAmount: target.delta?.flashloanAmount || ONE,
       borrowAmount: borrowEthAmountWei,
       fee: FEE,
       swapData: swapData.exchangeCalldata,

--- a/packages/oasis-actions/src/strategies/aave/openStEth.ts
+++ b/packages/oasis-actions/src/strategies/aave/openStEth.ts
@@ -7,7 +7,7 @@ import chainlinkPriceFeedABI from '../../abi/chainlinkPriceFeedABI.json'
 import { amountFromWei } from '../../helpers'
 import { Position } from '../../helpers/calculations/Position'
 import { RiskRatio } from '../../helpers/calculations/RiskRatio'
-import { ONE, ZERO } from '../../helpers/constants'
+import { UNUSED_FLASHLOAN_AMOUNT, ZERO } from '../../helpers/constants'
 import * as operation from '../../operations'
 import type { OpenStEthAddresses } from '../../operations/aave/openStEth'
 import { IStrategy } from '../types/IStrategy'
@@ -136,7 +136,7 @@ export async function openStEth(
 
   const calls = await operation.aave.openStEth(
     {
-      flashloanAmount: target.delta?.flashloanAmount || ONE,
+      flashloanAmount: target.delta?.flashloanAmount || UNUSED_FLASHLOAN_AMOUNT,
       borrowAmount: borrowEthAmountWei,
       fee: FEE,
       swapData: swapData.exchangeCalldata,


### PR DESCRIPTION
Sets default flashloan to one so that 1inch call doesn't fail when flashloan is not required.