### PR TITLE
Optional actions in operation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ packages/oasis-actions/src/helpers/calculations/credentials.json
 serviceRegistryEntries.txt
 
 #Hardhat files
+abi/generated
 cache
 artifacts
 

--- a/contracts/core/OperationExecutor.sol
+++ b/contracts/core/OperationExecutor.sol
@@ -76,9 +76,9 @@ contract OperationExecutor is IERC3156FlashBorrower {
     bool hasActionsToVerify = opStorage.hasActionsToVerify();
     for (uint256 current = 0; current < calls.length; current++) {
       if (hasActionsToVerify) {
-         opStorage.verifyAction(calls[current].targetHash, calls[current].skipped);
+        opStorage.verifyAction(calls[current].targetHash, calls[current].skipped);
       }
-      if(!calls[current].skipped) {
+      if (!calls[current].skipped) {
         address target = registry.getServiceAddress(calls[current].targetHash);
         target.execute(calls[current].callData);
       }

--- a/contracts/core/OperationExecutor.sol
+++ b/contracts/core/OperationExecutor.sol
@@ -62,7 +62,8 @@ contract OperationExecutor is IERC3156FlashBorrower {
     );
 
     opStorage.clearStorage();
-    opStorage.setOperationActions(opRegistry.getOperation(operationName));
+    (bytes32[] memory actions, bool[] memory optional) = opRegistry.getOperation(operationName);
+    opStorage.setOperationActions(actions, optional);
     aggregate(calls);
 
     opStorage.clearStorage();
@@ -75,11 +76,12 @@ contract OperationExecutor is IERC3156FlashBorrower {
     bool hasActionsToVerify = opStorage.hasActionsToVerify();
     for (uint256 current = 0; current < calls.length; current++) {
       if (hasActionsToVerify) {
-        opStorage.verifyAction(calls[current].targetHash);
+         opStorage.verifyAction(calls[current].targetHash, calls[current].skipped);
       }
-
-      address target = registry.getServiceAddress(calls[current].targetHash);
-      target.execute(calls[current].callData);
+      if(!calls[current].skipped) {
+        address target = registry.getServiceAddress(calls[current].targetHash);
+        target.execute(calls[current].callData);
+      }
     }
   }
 

--- a/contracts/core/OperationStorage.sol
+++ b/contracts/core/OperationStorage.sol
@@ -11,6 +11,7 @@ import { ServiceRegistry } from "./ServiceRegistry.sol";
 contract OperationStorage {
   uint8 internal action = 0;
   bytes32[] public actions;
+  bool[] public optionals;
   mapping(address => bytes32[]) public returnValues;
   address[] public valuesHolders;
   bool private locked;
@@ -55,16 +56,20 @@ contract OperationStorage {
   }
 
   /**
-   * @param _actions Stores the Actions currently being executed for a given Operation
+   * @param _actions Stores the Actions currently being executed for a given Operation and their optionality
    */
-  function setOperationActions(bytes32[] memory _actions) external {
+  function setOperationActions(bytes32[] memory _actions, bool[] memory _optionals) external {
     actions = _actions;
+    optionals = _optionals;
   }
 
   /**
    * @param actionHash Checks the current action has against the expected action hash
    */
-  function verifyAction(bytes32 actionHash) external {
+  function verifyAction(bytes32 actionHash, bool skipped) external {
+    if(skipped) {
+      require(optionals[action], "Action cannot be skipped");
+    }
     require(actions[action] == actionHash, "incorrect-action");
     registry.getServiceAddress(actionHash);
     action++;

--- a/contracts/core/OperationStorage.sol
+++ b/contracts/core/OperationStorage.sol
@@ -68,7 +68,7 @@ contract OperationStorage {
    * @param actionHash Checks the current action has against the expected action hash
    */
   function verifyAction(bytes32 actionHash, bool skipped) external {
-    if(skipped) {
+    if (skipped) {
       require(optionals[action], "Action cannot be skipped");
     }
     require(actions[action] == actionHash, "incorrect-action");

--- a/contracts/core/OperationsRegistry.sol
+++ b/contracts/core/OperationsRegistry.sol
@@ -43,13 +43,11 @@ contract OperationsRegistry {
 
   /**
    * @notice Adds an Operation's Actions keyed to a an operation name
-   * @param name The Operation name
-   * @param actions An array the Actions the Operation consists of
-   * @param optional An array indicating given Action can be skipped
+   * @param operation Struct with Operation name, actions and their optionality
    */
-  function addOperation(string memory name, bytes32[] memory actions, bool[] memory optional) external onlyOwner {
-    operations[name] = StoredOperation(actions, optional, name);
-    emit OperationAdded(name);
+  function addOperation(StoredOperation calldata operation) external onlyOwner {
+    operations[operation.name] = operation;
+    emit OperationAdded(operation.name);
   }
 
   /**

--- a/contracts/core/OperationsRegistry.sol
+++ b/contracts/core/OperationsRegistry.sol
@@ -5,12 +5,14 @@ import { OPERATIONS_REGISTRY } from "./constants/Common.sol";
 
 struct StoredOperation {
   bytes32[] actions;
+  bool[] optional;
   string name;
 }
 
 /**
  * @title Operation Registry
- * @notice Stores the Actions that constitute a given Operation
+ * @notice Stores the Actions that constitute a given Operation and information if an Action can be skipped
+
  */
 contract OperationsRegistry {
   mapping(string => StoredOperation) private operations;
@@ -43,21 +45,24 @@ contract OperationsRegistry {
    * @notice Adds an Operation's Actions keyed to a an operation name
    * @param name The Operation name
    * @param actions An array the Actions the Operation consists of
+   * @param optional An array indicating given Action can be skipped
    */
-  function addOperation(string memory name, bytes32[] memory actions) external onlyOwner {
-    operations[name] = StoredOperation(actions, name);
+  function addOperation(string memory name, bytes32[] memory actions, bool[] memory optional) external onlyOwner {
+    operations[name] = StoredOperation(actions, optional, name);
     emit OperationAdded(name);
   }
 
   /**
    * @notice Gets an Operation from the Registry
    * @param name The name of the Operation
-   * @return actions Returns an array of Actions
+   * @return actions Returns an array of Actions and array for optionality of coresponding Actions
    */
-  function getOperation(string memory name) external view returns (bytes32[] memory actions) {
+  function getOperation(string memory name) external view returns (bytes32[] memory actions, bool[] memory optional) {
     if (keccak256(bytes(operations[name].name)) == keccak256(bytes(""))) {
       revert("Operation doesn't exist");
     }
     actions = operations[name].actions;
+    optional = operations[name].optional;
+
   }
 }

--- a/contracts/core/OperationsRegistry.sol
+++ b/contracts/core/OperationsRegistry.sol
@@ -56,12 +56,15 @@ contract OperationsRegistry {
    * @param name The name of the Operation
    * @return actions Returns an array of Actions and array for optionality of coresponding Actions
    */
-  function getOperation(string memory name) external view returns (bytes32[] memory actions, bool[] memory optional) {
+  function getOperation(string memory name)
+    external
+    view
+    returns (bytes32[] memory actions, bool[] memory optional)
+  {
     if (keccak256(bytes(operations[name].name)) == keccak256(bytes(""))) {
       revert("Operation doesn't exist");
     }
     actions = operations[name].actions;
     optional = operations[name].optional;
-
   }
 }

--- a/contracts/core/types/Common.sol
+++ b/contracts/core/types/Common.sol
@@ -38,6 +38,7 @@ struct SwapData {
 struct Call {
   bytes32 targetHash;
   bytes callData;
+  bool skipped;
 }
 
 struct Operation {

--- a/contracts/test/DummyAction.sol
+++ b/contracts/test/DummyAction.sol
@@ -17,6 +17,7 @@ contract DummyAction is Executable, UseStore {
 
   function execute(bytes calldata data, uint8[] memory paramsMap) external payable override {
     store().write(bytes32("123"));
-    emit Action("DummyActionEvent", bytes32("Mandatory"));
+    emit Action("DummyActionEvent", bytes(abi.encode("Mandatory")));
+    
   }
 }

--- a/contracts/test/DummyAction.sol
+++ b/contracts/test/DummyAction.sol
@@ -18,6 +18,5 @@ contract DummyAction is Executable, UseStore {
   function execute(bytes calldata data, uint8[] memory paramsMap) external payable override {
     store().write(bytes32("123"));
     emit Action("DummyActionEvent", bytes(abi.encode("Mandatory")));
-    
   }
 }

--- a/contracts/test/DummyOptionalAction.sol
+++ b/contracts/test/DummyOptionalAction.sol
@@ -15,7 +15,7 @@ contract DummyOptionalAction is Executable, UseStore {
   constructor(address _registry) UseStore(_registry) {}
 
   function execute(bytes calldata data, uint8[] memory paramsMap) external payable override {
-    emit Action("DummyActionEvent", bytes(abi.encode("Optional")));
+    emit Action("DummyOptionalActionEvent", bytes(abi.encode("Optional")));
 
   }
 }

--- a/contracts/test/DummyOptionalAction.sol
+++ b/contracts/test/DummyOptionalAction.sol
@@ -7,7 +7,7 @@ import { UseStore, Read, Write } from "../actions/common/UseStore.sol";
 import { OperationStorage } from "../core/OperationStorage.sol";
 import { SET_APPROVAL_ACTION } from "../core/constants/Common.sol";
 
-contract DummyAction is Executable, UseStore {
+contract DummyOptionalAction is Executable, UseStore {
   using SafeERC20 for IERC20;
   using Read for OperationStorage;
   using Write for OperationStorage;
@@ -15,7 +15,6 @@ contract DummyAction is Executable, UseStore {
   constructor(address _registry) UseStore(_registry) {}
 
   function execute(bytes calldata data, uint8[] memory paramsMap) external payable override {
-    store().write(bytes32("123"));
-    emit Action("DummyActionEvent", bytes32("Mandatory"));
+     emit Action("DummyOptionalActionEvent", bytes32("Optional"));
   }
 }

--- a/contracts/test/DummyOptionalAction.sol
+++ b/contracts/test/DummyOptionalAction.sol
@@ -16,6 +16,5 @@ contract DummyOptionalAction is Executable, UseStore {
 
   function execute(bytes calldata data, uint8[] memory paramsMap) external payable override {
     emit Action("DummyOptionalActionEvent", bytes(abi.encode("Optional")));
-
   }
 }

--- a/contracts/test/DummyOptionalAction.sol
+++ b/contracts/test/DummyOptionalAction.sol
@@ -15,6 +15,7 @@ contract DummyOptionalAction is Executable, UseStore {
   constructor(address _registry) UseStore(_registry) {}
 
   function execute(bytes calldata data, uint8[] memory paramsMap) external payable override {
-     emit Action("DummyOptionalActionEvent", bytes32("Optional"));
+    emit Action("DummyActionEvent", bytes(abi.encode("Optional")));
+
   }
 }

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -10,6 +10,7 @@ import './tasks/proxy'
 import './tasks/verify-earn'
 import 'solidity-docgen'
 import 'hardhat-tracer'
+import 'hardhat-abi-exporter'
 
 import { default as dotenv } from 'dotenv'
 import { HardhatUserConfig, task } from 'hardhat/config'
@@ -125,6 +126,14 @@ const config: HardhatUserConfig = {
       './test',
     ],
   },
+  abiExporter: {
+    path: './abi/generated',
+    runOnCompile: true,
+    clear: true,
+    flat: true,
+    spacing: 2,
+    pretty: true,
+  }
 }
 
 export default config

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -133,7 +133,7 @@ const config: HardhatUserConfig = {
     flat: true,
     spacing: 2,
     pretty: true,
-  }
+  },
 }
 
 export default config

--- a/helpers/wrappers/operationsRegistry.ts
+++ b/helpers/wrappers/operationsRegistry.ts
@@ -9,11 +9,19 @@ export class OperationsRegistry {
     this.signer = signer
   }
 
-  async addOp(label: string, actionHashes: string[], debug = false): Promise<string> {
+  async addOp(
+    label: string,
+    actionHashes: string[],
+    optionals: boolean[],
+    debug = false,
+  ): Promise<string> {
+    if (actionHashes.length !== optionals.length) {
+      throw new Error('Actions and optionals arrays lenght missmatch')
+    }
     const ethers = (await import('hardhat')).ethers
     const entryHash = utils.keccak256(utils.toUtf8Bytes(label))
     const registry = await ethers.getContractAt('OperationsRegistry', this.address, this.signer)
-    await registry.addOperation(label, actionHashes)
+    await registry.addOperation(label, actionHashes, optionals)
 
     if (debug) {
       console.log(`DEBUG: Service '${label}' has been added with hash: ${entryHash}`)
@@ -22,7 +30,7 @@ export class OperationsRegistry {
     return entryHash
   }
 
-  async getOp(label: string): Promise<string[]> {
+  async getOp(label: string): Promise<[string[], boolean[]]> {
     const ethers = (await import('hardhat')).ethers
     const registry = await ethers.getContractAt('OperationsRegistry', this.address, this.signer)
 

--- a/helpers/wrappers/operationsRegistry.ts
+++ b/helpers/wrappers/operationsRegistry.ts
@@ -11,17 +11,17 @@ export class OperationsRegistry {
 
   async addOp(
     label: string,
-    actionHashes: string[],
-    optionals: boolean[],
+    actions: string[],
+    optional: boolean[],
     debug = false,
   ): Promise<string> {
-    if (actionHashes.length !== optionals.length) {
+    if (actions.length !== optional.length) {
       throw new Error('Actions and optionals arrays lenght missmatch')
     }
     const ethers = (await import('hardhat')).ethers
     const entryHash = utils.keccak256(utils.toUtf8Bytes(label))
     const registry = await ethers.getContractAt('OperationsRegistry', this.address, this.signer)
-    await registry.addOperation(label, actionHashes, optionals)
+    await registry.addOperation({ name: label, actions, optional })
 
     if (debug) {
       console.log(`DEBUG: Service '${label}' has been added with hash: ${entryHash}`)

--- a/packages/oasis-actions/src/actions/actionFactory.ts
+++ b/packages/oasis-actions/src/actions/actionFactory.ts
@@ -17,6 +17,7 @@ export class ActionFactory {
     return {
       targetHash,
       callData: calldata,
+      skipped: false,
     }
   }
 }

--- a/packages/oasis-actions/src/actions/types/actionCall.ts
+++ b/packages/oasis-actions/src/actions/types/actionCall.ts
@@ -1,4 +1,5 @@
 export type ActionCall = {
   targetHash: string
   callData: string
+  skipped: boolean
 }

--- a/packages/oasis-actions/src/actions/types/actions.ts
+++ b/packages/oasis-actions/src/actions/types/actions.ts
@@ -13,7 +13,7 @@ export const calldataTypes = {
     UnwrapEth: `tuple(uint256 amount)`,
     ReturnFunds: `tuple(address asset)`,
     PullToken: `tuple(address asset, address from, uint256 amount)`,
-    TakeAFlashLoan: `tuple(uint256 amount, bool dsProxyFlashloan, (bytes32 targetHash, bytes callData)[] calls)`,
+    TakeAFlashLoan: `tuple(uint256 amount, bool dsProxyFlashloan, (bytes32 targetHash, bytes callData, bool skipped)[] calls)`,
   },
   maker: {
     Open: `tuple(address joinAddress)`,

--- a/packages/oasis-actions/src/helpers/constants.ts
+++ b/packages/oasis-actions/src/helpers/constants.ts
@@ -55,6 +55,7 @@ export const CONTRACT_NAMES = {
   },
   test: {
     DUMMY_ACTION: 'DummyAction',
+    DUMMY_OPTIONAL_ACTION: 'DummyOptionalAction',
     DUMMY_SWAP: 'DummySwap',
     DUMMY_EXCHANGE: 'DummyExchange',
     SWAP: 'uSwap',

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -318,16 +318,20 @@ async function main() {
       },
     ],
   )
-  await operationsRegistry.addOp(OPERATION_NAMES.aave.OPEN_POSITION, [
-    pullTokenHash,
-    takeAFlashloanHash,
-    setApprovalHash,
-    depositInAAVEHash,
-    aaveBorrowHash,
-    swapActionHash,
-    withdrawFromAAVEHash,
-    sendTokenHash,
-  ])
+  await operationsRegistry.addOp(
+    OPERATION_NAMES.aave.OPEN_POSITION,
+    [
+      pullTokenHash,
+      takeAFlashloanHash,
+      setApprovalHash,
+      depositInAAVEHash,
+      aaveBorrowHash,
+      swapActionHash,
+      withdrawFromAAVEHash,
+      sendTokenHash,
+    ],
+    Array(8).fill(false),
+  )
 
   await approve(ADDRESSES.main.DAI, proxyAddress, depositAmount, config, true)
 

--- a/tasks/deploy/index.ts
+++ b/tasks/deploy/index.ts
@@ -347,16 +347,20 @@ async function addAAVEOperationsToRegistry(
     sendTokenHash,
   } = hashes
 
-  await operationsRegistry.addOp(OPERATION_NAMES.aave.OPEN_POSITION, [
-    pullTokenHash,
-    takeAFlashloanHash,
-    setApprovalHash,
-    depositInAAVEHash,
-    borromFromAAVEHash,
-    swapActionHash,
-    withdrawFromAAVEHash,
-    sendTokenHash,
-  ])
+  await operationsRegistry.addOp(
+    OPERATION_NAMES.aave.OPEN_POSITION,
+    [
+      pullTokenHash,
+      takeAFlashloanHash,
+      setApprovalHash,
+      depositInAAVEHash,
+      borromFromAAVEHash,
+      swapActionHash,
+      withdrawFromAAVEHash,
+      sendTokenHash,
+    ],
+    Array(8).fill(false),
+  )
 
-  await operationsRegistry.addOp(OPERATION_NAMES.common.CUSTOM_OPERATION, [])
+  await operationsRegistry.addOp(OPERATION_NAMES.common.CUSTOM_OPERATION, [], [])
 }

--- a/test/common/OptionalActions.test.ts
+++ b/test/common/OptionalActions.test.ts
@@ -1,0 +1,163 @@
+import { JsonRpcProvider } from '@ethersproject/providers'
+import { ActionFactory, ADDRESSES, calldataTypes, CONTRACT_NAMES } from '@oasisdex/oasis-actions'
+import { ActionCall } from '@oasisdex/oasis-actions/src/actions/types/actionCall'
+import BigNumber from 'bignumber.js'
+import { expect } from 'chai'
+import { loadFixture } from 'ethereum-waffle'
+import { Signer, utils } from 'ethers'
+
+import { executeThroughProxy } from '../../helpers/deploy'
+import { restoreSnapshot } from '../../helpers/restoreSnapshot'
+import { ServiceRegistry } from '../../helpers/serviceRegistry'
+import { RuntimeConfig } from '../../helpers/types/common'
+import { OperationsRegistry } from '../../helpers/wrappers/operationsRegistry'
+import { testBlockNumber } from '../config'
+import { DeployedSystemInfo } from '../deploySystem'
+import { initialiseConfig } from '../fixtures/setup'
+
+const createAction = ActionFactory.create
+
+async function executeOperation(
+  system: DeployedSystemInfo,
+  calls: ActionCall[],
+  operationName: string,
+  signer: Signer,
+  wrapAmount: BigNumber,
+) {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const [success, _] = await executeThroughProxy(
+    system.common.userProxyAddress,
+    {
+      address: system.common.operationExecutor.address,
+      calldata: system.common.operationExecutor.interface.encodeFunctionData('executeOp', [
+        calls,
+        operationName,
+      ]),
+    },
+    signer,
+    wrapAmount.toString(),
+  )
+
+  return success
+}
+describe(`Common | Optional Actions`, async () => {
+  let provider: JsonRpcProvider
+  let signer: Signer
+  let system: DeployedSystemInfo
+  let config: RuntimeConfig
+  let operationsRegistry: OperationsRegistry
+  let wrapAmount: BigNumber
+  let OPERATION_NAME: string
+  let OpenVaultHash: string
+  let WrapEthHash: string
+  let setApprovalHash: string
+  let openVaultAction: ActionCall
+  let wrapEthAction: ActionCall
+  let setApprovalAction: ActionCall
+
+  beforeEach(async () => {
+    ;({ config, provider, signer } = await loadFixture(initialiseConfig))
+
+    const { snapshot } = await restoreSnapshot({ config, provider, blockNumber: testBlockNumber })
+    system = snapshot.deployed.system
+
+    wrapAmount = new BigNumber(10000)
+    operationsRegistry = new OperationsRegistry(system.common.operationRegistry.address, signer)
+
+    // Add new operation with optional Actions
+    OPERATION_NAME = 'TEST_OPERATION_1'
+    OpenVaultHash = utils.keccak256(utils.toUtf8Bytes(CONTRACT_NAMES.maker.OPEN_VAULT))
+    WrapEthHash = utils.keccak256(utils.toUtf8Bytes(CONTRACT_NAMES.common.WRAP_ETH))
+    setApprovalHash = utils.keccak256(utils.toUtf8Bytes(CONTRACT_NAMES.common.SET_APPROVAL))
+
+    await operationsRegistry.addOp(
+      OPERATION_NAME,
+      [OpenVaultHash, WrapEthHash, setApprovalHash],
+      [false, true, false],
+    )
+
+    openVaultAction = createAction(
+      OpenVaultHash,
+      [calldataTypes.maker.Open, calldataTypes.paramsMap],
+      [
+        {
+          joinAddress: ADDRESSES.main.maker.joinETH_A,
+        },
+        [0],
+      ],
+    )
+
+    wrapEthAction = createAction(
+      WrapEthHash,
+      [calldataTypes.common.WrapEth, calldataTypes.paramsMap],
+      [
+        {
+          amount: wrapAmount.toFixed(0),
+        },
+        [0],
+      ],
+    )
+
+    setApprovalAction = createAction(
+      setApprovalHash,
+      [calldataTypes.common.Approval, calldataTypes.paramsMap],
+      [
+        {
+          asset: ADDRESSES.main.DAI,
+          delegate: ADDRESSES.main.lender,
+          amount: new BigNumber(100).toFixed(0),
+          sumAmounts: false,
+        },
+        [0, 0, 0, 0],
+      ],
+    )
+  })
+
+  afterEach(async () => {
+    await restoreSnapshot({ config, provider, blockNumber: testBlockNumber })
+  })
+
+  describe(`Regular Operation successful`, async () => {
+    it(`should execute an Operation successfully`, async () => {
+      const success = await executeOperation(
+        system,
+        [openVaultAction, wrapEthAction, setApprovalAction],
+        OPERATION_NAME,
+        signer,
+        wrapAmount,
+      )
+
+      expect(success).to.be.eq(true)
+    })
+  })
+
+  describe(`Operation with skipped Action successful`, async () => {
+    it(`should execute an Operation successfully with optional Action skipped`, async () => {
+      wrapEthAction.skipped = true
+      const success = await executeOperation(
+        system,
+        [openVaultAction, wrapEthAction, setApprovalAction],
+        OPERATION_NAME,
+        signer,
+        wrapAmount,
+      )
+
+      expect(success).to.be.eq(true)
+    })
+  })
+
+  describe(`Operation with mandatory Action skipped`, async () => {
+    it(`should fail executing an Operation with mandatory Action skipped`, async () => {
+      setApprovalAction.skipped = true
+      const success = await executeOperation(
+        system,
+        [openVaultAction, wrapEthAction, setApprovalAction],
+        OPERATION_NAME,
+        signer,
+        wrapAmount,
+      )
+
+      expect(success).to.be.eq(false)
+    })
+  })
+})

--- a/test/common/OptionalActions.test.ts
+++ b/test/common/OptionalActions.test.ts
@@ -139,9 +139,15 @@ describe(`Common | Optional Actions`, async () => {
 
       expect(success).to.be.eq(true)
       expect(actionLogs.length).to.be.eq(3)
-      expect(actionLogs[0].args[0]).to.be.eq('DummyActionEvent')
-      expect(actionLogs[1].args[0]).to.be.eq('DummyOptionalActionEvent')
-      expect(actionLogs[2].args[0]).to.be.eq('DummyActionEvent')
+      expect(actionLogs[0].args[0].hash).to.be.eq(
+        ethers.utils.keccak256(utils.toUtf8Bytes('DummyActionEvent')),
+      )
+      expect(actionLogs[1].args[0].hash).to.be.eq(
+        ethers.utils.keccak256(utils.toUtf8Bytes('DummyOptionalActionEvent')),
+      )
+      expect(actionLogs[2].args[0].hash).to.be.eq(
+        ethers.utils.keccak256(utils.toUtf8Bytes('DummyActionEvent')),
+      )
     })
   })
 
@@ -160,8 +166,12 @@ describe(`Common | Optional Actions`, async () => {
 
       expect(success).to.be.eq(true)
       expect(actionLogs.length).to.be.eq(2)
-      expect(actionLogs[0].args[0]).to.be.eq('DummyActionEvent')
-      expect(actionLogs[1].args[0]).to.be.eq('DummyActionEvent')
+      expect(actionLogs[0].args[0].hash).to.be.eq(
+        ethers.utils.keccak256(utils.toUtf8Bytes('DummyActionEvent')),
+      )
+      expect(actionLogs[1].args[0].hash).to.be.eq(
+        ethers.utils.keccak256(utils.toUtf8Bytes('DummyActionEvent')),
+      )
     })
   })
 

--- a/test/common/OptionalActions.test.ts
+++ b/test/common/OptionalActions.test.ts
@@ -8,7 +8,6 @@ import { Signer, utils } from 'ethers'
 
 import { executeThroughProxy } from '../../helpers/deploy'
 import { restoreSnapshot } from '../../helpers/restoreSnapshot'
-import { ServiceRegistry } from '../../helpers/serviceRegistry'
 import { RuntimeConfig } from '../../helpers/types/common'
 import { OperationsRegistry } from '../../helpers/wrappers/operationsRegistry'
 import { testBlockNumber } from '../config'

--- a/test/deploySystem.ts
+++ b/test/deploySystem.ts
@@ -90,6 +90,9 @@ export async function deploySystem(config: RuntimeConfig, debug = false, useFall
   const [, dummyActionAddress] = await deploy(CONTRACT_NAMES.test.DUMMY_ACTION, [
     serviceRegistryAddress,
   ])
+  const [, dummyOptionalActionAddress] = await deploy(CONTRACT_NAMES.test.DUMMY_OPTIONAL_ACTION, [
+    serviceRegistryAddress,
+  ])
 
   const [pullToken, pullTokenAddress] = await deploy(CONTRACT_NAMES.common.PULL_TOKEN, [])
 
@@ -180,6 +183,7 @@ export async function deploySystem(config: RuntimeConfig, debug = false, useFall
   )
   const sendTokenHash = await registry.addEntry(CONTRACT_NAMES.common.SEND_TOKEN, sendTokenAddress)
   await registry.addEntry(CONTRACT_NAMES.test.DUMMY_ACTION, dummyActionAddress)
+  await registry.addEntry(CONTRACT_NAMES.test.DUMMY_OPTIONAL_ACTION, dummyOptionalActionAddress)
   const pullTokenHash = await registry.addEntry(CONTRACT_NAMES.common.PULL_TOKEN, pullTokenAddress)
   const setApprovalHash = await registry.addEntry(
     CONTRACT_NAMES.common.SET_APPROVAL,

--- a/test/deploySystem.ts
+++ b/test/deploySystem.ts
@@ -383,33 +383,38 @@ export async function deploySystem(config: RuntimeConfig, debug = false, useFall
     ],
     Array(8).fill(false),
   )
-  await operationsRegistry.addOp(OPERATION_NAMES.aave.OPEN_POSITION, [
-    takeFlashLoanHash,
-    setApprovalHash,
-    aaveDepositHash,
-    aaveBorrowHash,
-    wrapEthHash,
-    swapActionHash,
-    setApprovalHash,
-    aaveDepositHash,
-    aaveWithdrawHash,
-  ],
-  Array(9).fill(false),
+  await operationsRegistry.addOp(
+    OPERATION_NAMES.aave.OPEN_POSITION,
+    [
+      takeFlashLoanHash,
+      setApprovalHash,
+      aaveDepositHash,
+      aaveBorrowHash,
+      wrapEthHash,
+      swapActionHash,
+      setApprovalHash,
+      aaveDepositHash,
+      aaveWithdrawHash,
+    ],
+    Array(9).fill(false),
   )
 
-  await operationsRegistry.addOp(OPERATION_NAMES.aave.CLOSE_POSITION, [
-    takeFlashLoanHash,
-    setApprovalHash,
-    aaveDepositHash,
-    aaveWithdrawHash,
-    swapActionHash,
-    setApprovalHash,
-    aavePaybackHash,
-    aaveWithdrawHash,
-    unwrapEthHash,
-    returnFundsActionHash,
-  ],
-  Array(10).fill(false))
+  await operationsRegistry.addOp(
+    OPERATION_NAMES.aave.CLOSE_POSITION,
+    [
+      takeFlashLoanHash,
+      setApprovalHash,
+      aaveDepositHash,
+      aaveWithdrawHash,
+      swapActionHash,
+      setApprovalHash,
+      aavePaybackHash,
+      aaveWithdrawHash,
+      unwrapEthHash,
+      returnFundsActionHash,
+    ],
+    Array(10).fill(false),
+  )
 
   const deployedContracts = {
     common: {

--- a/test/deploySystem.ts
+++ b/test/deploySystem.ts
@@ -253,71 +253,94 @@ export async function deploySystem(config: RuntimeConfig, debug = false, useFall
     operationsRegistryAddress,
     signer,
   )
-  await operationsRegistry.addOp(OPERATION_NAMES.common.CUSTOM_OPERATION, [])
+  await operationsRegistry.addOp(OPERATION_NAMES.common.CUSTOM_OPERATION, [], [])
 
-  await operationsRegistry.addOp(OPERATION_NAMES.maker.OPEN_AND_DRAW, [
-    makerOpenVaultHash,
-    pullTokenHash,
-    makerDepositHash,
-    makerGenerateHash,
-  ])
-  await operationsRegistry.addOp(OPERATION_NAMES.maker.OPEN_DRAW_AND_CLOSE, [
-    makerOpenVaultHash,
-    pullTokenHash,
-    makerDepositHash,
-    makerGenerateHash,
-    makerPaybackHash,
-    makerWithdrawHash,
-  ])
-  await operationsRegistry.addOp(OPERATION_NAMES.maker.INCREASE_MULTIPLE, [
-    makerOpenVaultHash,
-    pullTokenHash,
-    makerDepositHash,
-    makerGenerateHash,
-    swapActionHash,
-    makerDepositHash,
-  ])
-  await operationsRegistry.addOp(OPERATION_NAMES.maker.INCREASE_MULTIPLE_WITH_DAI_TOP_UP, [
-    makerOpenVaultHash,
-    pullTokenHash,
-    makerDepositHash,
-    pullTokenHash,
-    makerGenerateHash,
-    swapActionHash,
-    makerDepositHash,
-  ])
-  await operationsRegistry.addOp(OPERATION_NAMES.maker.INCREASE_MULTIPLE_WITH_COLL_TOP_UP, [
-    makerOpenVaultHash,
-    pullTokenHash,
-    makerDepositHash,
-    pullTokenHash,
-    makerDepositHash,
-    makerGenerateHash,
-    swapActionHash,
-    makerDepositHash,
-  ])
-  await operationsRegistry.addOp(OPERATION_NAMES.maker.INCREASE_MULTIPLE_WITH_DAI_AND_COLL_TOP_UP, [
-    makerOpenVaultHash,
-    pullTokenHash,
-    makerDepositHash,
-    pullTokenHash,
-    pullTokenHash,
-    makerDepositHash,
-    makerGenerateHash,
-    swapActionHash,
-    makerDepositHash,
-  ])
-  await operationsRegistry.addOp(OPERATION_NAMES.maker.INCREASE_MULTIPLE_WITH_FLASHLOAN, [
-    makerOpenVaultHash,
-    pullTokenHash,
-    makerDepositHash,
-    takeFlashLoanHash,
-    // pullTokenHash,
-    swapActionHash,
-    makerDepositHash,
-    makerGenerateHash,
-    sendTokenHash,
-  ])
+  await operationsRegistry.addOp(
+    OPERATION_NAMES.maker.OPEN_AND_DRAW,
+    [makerOpenVaultHash, pullTokenHash, makerDepositHash, makerGenerateHash],
+    Array(4).fill(false),
+  )
+  await operationsRegistry.addOp(
+    OPERATION_NAMES.maker.OPEN_DRAW_AND_CLOSE,
+    [
+      makerOpenVaultHash,
+      pullTokenHash,
+      makerDepositHash,
+      makerGenerateHash,
+      makerPaybackHash,
+      makerWithdrawHash,
+    ],
+    Array(6).fill(false),
+  )
+  await operationsRegistry.addOp(
+    OPERATION_NAMES.maker.INCREASE_MULTIPLE,
+    [
+      makerOpenVaultHash,
+      pullTokenHash,
+      makerDepositHash,
+      makerGenerateHash,
+      swapActionHash,
+      makerDepositHash,
+    ],
+    Array(6).fill(false),
+  )
+  await operationsRegistry.addOp(
+    OPERATION_NAMES.maker.INCREASE_MULTIPLE_WITH_DAI_TOP_UP,
+    [
+      makerOpenVaultHash,
+      pullTokenHash,
+      makerDepositHash,
+      pullTokenHash,
+      makerGenerateHash,
+      swapActionHash,
+      makerDepositHash,
+    ],
+    Array(7).fill(false),
+  )
+  await operationsRegistry.addOp(
+    OPERATION_NAMES.maker.INCREASE_MULTIPLE_WITH_COLL_TOP_UP,
+    [
+      makerOpenVaultHash,
+      pullTokenHash,
+      makerDepositHash,
+      pullTokenHash,
+      makerDepositHash,
+      makerGenerateHash,
+      swapActionHash,
+      makerDepositHash,
+    ],
+    Array(8).fill(false),
+  )
+  await operationsRegistry.addOp(
+    OPERATION_NAMES.maker.INCREASE_MULTIPLE_WITH_DAI_AND_COLL_TOP_UP,
+    [
+      makerOpenVaultHash,
+      pullTokenHash,
+      makerDepositHash,
+      pullTokenHash,
+      pullTokenHash,
+      makerDepositHash,
+      makerGenerateHash,
+      swapActionHash,
+      makerDepositHash,
+    ],
+    Array(9).fill(false),
+  )
+  await operationsRegistry.addOp(
+    OPERATION_NAMES.maker.INCREASE_MULTIPLE_WITH_FLASHLOAN,
+    [
+      makerOpenVaultHash,
+      pullTokenHash,
+      makerDepositHash,
+      takeFlashLoanHash,
+      // pullTokenHash,
+      swapActionHash,
+      makerDepositHash,
+      makerGenerateHash,
+      sendTokenHash,
+    ],
+    Array(8).fill(false),
+  )
   await operationsRegistry.addOp(
     OPERATION_NAMES.maker.INCREASE_MULTIPLE_WITH_FLASHLOAN_AND_DAI_AND_COLL_TOP_UP,
     [
@@ -334,19 +357,24 @@ export async function deploySystem(config: RuntimeConfig, debug = false, useFall
       makerGenerateHash,
       sendTokenHash,
     ],
+    Array(11).fill(false),
   )
 
   // Add AAVE Operations
-  await operationsRegistry.addOp(OPERATION_NAMES.aave.OPEN_POSITION, [
-    pullTokenHash,
-    takeFlashLoanHash,
-    setApprovalHash,
-    aaveDepositHash,
-    aaveBorrowHash,
-    swapHash,
-    aaveWithdrawHash,
-    sendTokenHash,
-  ])
+  await operationsRegistry.addOp(
+    OPERATION_NAMES.aave.OPEN_POSITION,
+    [
+      pullTokenHash,
+      takeFlashLoanHash,
+      setApprovalHash,
+      aaveDepositHash,
+      aaveBorrowHash,
+      swapHash,
+      aaveWithdrawHash,
+      sendTokenHash,
+    ],
+    Array(8).fill(false),
+  )
 
   const deployedContracts = {
     common: {


### PR DESCRIPTION
Optional actions in operation are marked by passing additional array when creating operation in the OperationRegistry, e.g.:

`[ Action1, Action2, Action3, Actions4]` - actions hashes list
`[false, true, false, false]` - optionality list

In above case `Action2` can be skipped. 

Skipping when forming an operation on FE can be achieved by adding param `skipped = true`. This action still has to exist in operation, but all params can be omitted. It requires only actionHash and `skipped` param.

