### PR TITLE
Add `dev` script to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "steth:fallback": "npx hardhat createPosition --usefallbackswap --network local",
     "close": "npx hardhat closePosition --network local",
     "close:fallback": "npx hardhat closePosition --usefallbackswap --network local",
-    "update-block": "node update-block-number.ts"
+    "update-block": "node update-block-number.ts",
+    "dev": "cd ./packages/oasis-actions/ && tsc -b && cd ../../ && yarn update-block && npx hardhat node --max-memory 8192 --fork $(grep MAINNET_URL ./.env | cut -d '=' -f2)"
   },
   "devDependencies": {
     "@google-cloud/local-auth": "2.1.1",


### PR DESCRIPTION
# Add `dev` script to `package.json`

Created `dev` script that works as as shortcut for running dev enviroment:
- runs `tsc -b` in `/packages/oasis-actions/` directory,
- runs `update-block`,
- starts hardhat using `MAINNET_URL` from `.env` file.

One important note, `MAINNET_URL` in `.env` has to be without quotes:

```
MAINNET_URL=https://some.funny.url
```