### PR TITLE
Test for payback/withdraw for multiply

### DIFF
--- a/contracts/actions/common/SendToken.sol
+++ b/contracts/actions/common/SendToken.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.15;
 import { Executable } from "../common/Executable.sol";
 import { SafeERC20, IERC20 } from "../../libs/SafeERC20.sol";
 import { SendTokenData } from "../../core/types/Common.sol";
-import { SEND_TOKEN_ACTION, ETH } from "../../core/constants/Common.sol";
+import { SEND_TOKEN_ACTION } from "../../core/constants/Common.sol";
 
 /**
  * @title SendToken Action contract
@@ -19,15 +19,7 @@ contract SendToken is Executable {
   function execute(bytes calldata data, uint8[] memory) external payable override {
     SendTokenData memory send = parseInputs(data);
 
-    if (send.asset == ETH && send.amount == type(uint256).max) {
-      send.amount = address(this).balance;
-    }
-
-    if (send.asset != ETH && send.amount == type(uint256).max) {
-      send.amount = IERC20(send.asset).balanceOf(address(this));
-    }
-
-    if (send.asset == ETH) {
+    if (msg.value > 0) {
       payable(send.to).transfer(send.amount);
     } else {
       IERC20(send.asset).safeTransfer(send.to, send.amount);

--- a/contracts/test/dpm/AccountImplementation.sol
+++ b/contracts/test/dpm/AccountImplementation.sol
@@ -62,4 +62,14 @@ contract AccountImplementation {
       }
     }
   }
+
+  receive() external payable {
+    emit FundsRecived(msg.sender, msg.value);
+  }
+
+  function owner() external view returns (address) {
+    return guard.owners(address(this));
+  }
+
+  event FundsRecived(address sender, uint256 amount);
 }

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -14,6 +14,7 @@ import 'solidity-docgen'
 import 'hardhat-tracer'
 import 'hardhat-abi-exporter'
 import './tasks/userDpmProxies'
+import './tasks/createMultiplyPosition'
 
 import { default as dotenv } from 'dotenv'
 import { HardhatUserConfig, task } from 'hardhat/config'

--- a/helpers/aave/buildGetTokenFunction.ts
+++ b/helpers/aave/buildGetTokenFunction.ts
@@ -1,0 +1,48 @@
+import { AAVETokens } from '@oasisdex/oasis-actions'
+
+import erc20abi from '../../abi/external/IERC20.json'
+import { mainnetAddresses } from '../../test/addresses'
+import { HardhatRuntimeConfig } from '../types/common'
+
+export type AAVETokensToGet = Exclude<AAVETokens, 'ETH' | 'WETH'>
+const tokensWhales: Record<AAVETokensToGet, { whale: string; tokenAddress: string }> = {
+  STETH: {
+    tokenAddress: mainnetAddresses.STETH,
+    whale: '0x41318419cfa25396b47a94896ffa2c77c6434040',
+  },
+  WBTC: {
+    tokenAddress: mainnetAddresses.WBTC,
+    whale: '0x051d091b254ecdbbb4eb8e6311b7939829380b27',
+  },
+  USDC: {
+    whale: '0xdea0da1c96f1beb756d61225577ebdeb4bbd364e',
+    tokenAddress: mainnetAddresses.USDC,
+  },
+}
+
+export function buildGetTokenFunction(
+  config: HardhatRuntimeConfig,
+): (symbol: AAVETokensToGet, amount: string) => Promise<boolean> {
+  return async function getTokens(symbol: AAVETokensToGet, amount: string): Promise<boolean> {
+    const { tokenAddress, whale } = tokensWhales[symbol]
+    const fromSigner = await config.ethers.getSigner(whale)
+
+    await config.signer.sendTransaction({
+      from: await config.signer.getAddress(),
+      to: whale,
+      value: config.ethers.utils.parseEther('1'),
+      gasLimit: config.ethers.utils.hexlify(1000000),
+    })
+
+    await config.network.provider.request({
+      method: 'hardhat_impersonateAccount',
+      params: [whale],
+    })
+
+    const fromTokenContract = new config.ethers.Contract(tokenAddress, erc20abi, fromSigner)
+
+    await fromTokenContract.transfer(config.address, config.ethers.utils.parseUnits(amount, 'wei'))
+
+    return true
+  }
+}

--- a/helpers/aave/index.ts
+++ b/helpers/aave/index.ts
@@ -1,2 +1,3 @@
 export * from './AAVEAccountData'
 export * from './AAVEReserveData'
+export { AAVETokensToGet, buildGetTokenFunction } from './buildGetTokenFunction'

--- a/helpers/init.ts
+++ b/helpers/init.ts
@@ -1,7 +1,7 @@
 import { providers } from 'ethers'
 import { HardhatRuntimeEnvironment } from 'hardhat/types'
 
-import { RuntimeConfig } from './types/common'
+import { HardhatRuntimeConfig, RuntimeConfig } from './types/common'
 
 export default async function init(
   hre?: HardhatRuntimeEnvironment,
@@ -25,6 +25,30 @@ export default async function init(
   }
 }
 
+export async function hardhatInit(
+  hre?: HardhatRuntimeEnvironment,
+  impersonateAccount?: (
+    provider: providers.JsonRpcProvider,
+  ) => Promise<{ signer: providers.JsonRpcSigner; address: string }>,
+): Promise<HardhatRuntimeConfig> {
+  const ethers = hre ? hre.ethers : (await import('hardhat')).ethers
+  const network = hre ? hre.network : (await import('hardhat')).network
+  const provider = ethers.provider
+  let signer = provider.getSigner()
+  let address = await signer.getAddress()
+
+  if (impersonateAccount) {
+    ;({ signer, address } = await impersonateAccount(provider))
+  }
+
+  return {
+    provider,
+    signer,
+    address,
+    ethers,
+    network,
+  }
+}
 const testBlockNumber = Number(process.env.TESTS_BLOCK_NUMBER)
 export async function resetNode(
   provider: providers.JsonRpcProvider,

--- a/helpers/swap/DummyExchange.ts
+++ b/helpers/swap/DummyExchange.ts
@@ -54,7 +54,7 @@ async function exchangeToToken(provider: JsonRpcProvider, signer: Signer, token:
     amountToWei(200).toFixed(0),
     amountToWei(ONE, token.precision).toFixed(0),
     address,
-    { provider, signer, address },
+    { provider, signer },
   )
 }
 

--- a/helpers/swap/uniswap.ts
+++ b/helpers/swap/uniswap.ts
@@ -19,7 +19,7 @@ export async function swapUniswapTokens(
   amountIn: string,
   amountOutMinimum: string,
   recipient: string,
-  { provider, signer }: RuntimeConfig,
+  { provider, signer }: Pick<RuntimeConfig, 'provider' | 'signer'>,
 ) {
   const value = tokenIn === ADDRESSES.main.WETH ? amountIn : 0
 

--- a/helpers/types/common.ts
+++ b/helpers/types/common.ts
@@ -1,4 +1,5 @@
 import { ethers, providers } from 'ethers'
+import { HardhatRuntimeEnvironment } from 'hardhat/types'
 
 export type ValueOf<T> = T[keyof T]
 
@@ -34,6 +35,11 @@ export interface RuntimeConfig {
 export type WithRuntimeConfig = {
   config: RuntimeConfig
 }
+
+export type HardhatRuntimeConfig = {
+  ethers: HardhatRuntimeEnvironment['ethers']
+  network: HardhatRuntimeEnvironment['network']
+} & RuntimeConfig
 
 export type BalanceOptions = Debug & FormatUnit & WithRuntimeConfig
 

--- a/packages/oasis-actions/package.json
+++ b/packages/oasis-actions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oasisdex/oasis-actions",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "main": "lib/src/index.js",
   "typings": "lib/src/index.d.ts",
   "scripts": {

--- a/packages/oasis-actions/package.json
+++ b/packages/oasis-actions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oasisdex/oasis-actions",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "main": "lib/src/index.js",
   "typings": "lib/src/index.d.ts",
   "scripts": {

--- a/packages/oasis-actions/src/helpers/addresses/common.json
+++ b/packages/oasis-actions/src/helpers/addresses/common.json
@@ -19,6 +19,8 @@
     "proxyRegistry": "0x4678f0a6958e4D2Bc4F1BAF7Bc52E8F3564f3fE4",
     "chainlinkEthUsdPriceFeed": "0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419",
     "aavePriceOracle": "0xa50ba011c48153de246e5192c8f9258a2ba79ca9",
-    "operationExecutor": "0x5ab3e51608cea26090445ca89bc91628c8bb99f9"
+    "operationExecutor": "0x5ab3e51608cea26090445ca89bc91628c8bb99f9",
+    "accountFactory": "0xF7B75183A2829843dB06266c114297dfbFaeE2b6",
+    "accountGuard": "0xCe91349d2A4577BBd0fC91Fe6019600e047f2847"
   }
 }

--- a/packages/oasis-actions/src/operations/aave/paybackWithdraw.ts
+++ b/packages/oasis-actions/src/operations/aave/paybackWithdraw.ts
@@ -63,8 +63,8 @@ export async function paybackWithdraw(args: {
 
   withdrawCollateralFromAAVE.skipped = args.amountCollateralToWithdrawInBaseUnit.lte(ZERO)
   unwrapEth.skipped = args.amountCollateralToWithdrawInBaseUnit.lte(ZERO) || !args.collateralIsEth
-  sendTokenToUser.skipped = args.amountCollateralToWithdrawInBaseUnit.lte(ZERO) || !args.isDPMProxy
-  returnFunds.skipped = args.amountCollateralToWithdrawInBaseUnit.lte(ZERO) || args.isDPMProxy
+  sendTokenToUser.skipped = true // right now DPM has owner functionality, so it will work.
+  returnFunds.skipped = args.amountCollateralToWithdrawInBaseUnit.lte(ZERO)
 
   const calls = [
     pullDebtTokensToProxy,

--- a/tasks/createMultiplyPosition/index.ts
+++ b/tasks/createMultiplyPosition/index.ts
@@ -1,0 +1,177 @@
+import { ADDRESSES, CONTRACT_NAMES } from '@oasisdex/oasis-actions'
+import { task } from 'hardhat/config'
+
+import { buildGetTokenFunction } from '../../helpers/aave'
+import { hardhatInit } from '../../helpers/init'
+import { getOneInchCall } from '../../helpers/swap/OneInchCall'
+import { oneInchCallMock } from '../../helpers/swap/OneInchCallMock'
+import {
+  createDPMAccount,
+  createEthUsdcMultiplyAAVEPosition,
+  createStEthUsdcMultiplyAAVEPosition,
+  createWbtcUsdcMultiplyAAVEPosition,
+} from '../../test/fixtures/factories'
+import { StrategiesDependencies } from '../../test/fixtures/types'
+
+task('createMultiplyPosition', 'Create stETH position on AAVE')
+  .addOptionalParam<string>('serviceRegistry', 'Service Registry address')
+  .addFlag('usefallbackswap', 'Use fallback swap')
+  .setAction(async (taskArgs, hre) => {
+    const config = await hardhatInit(hre)
+
+    const getToken = buildGetTokenFunction(config)
+
+    const serviceRegistryAddress = taskArgs.serviceRegistry || process.env.SERVICE_REGISTRY_ADDRESS
+
+    if (!serviceRegistryAddress) {
+      throw new Error('ServiceRegistry params or SERVICE_REGISTRY_ADDRESS env variable is not set')
+    }
+
+    const serviceRegistryAbi = [
+      {
+        inputs: [
+          {
+            internalType: 'string',
+            name: 'serviceName',
+            type: 'string',
+          },
+        ],
+        name: 'getRegisteredService',
+        outputs: [
+          {
+            internalType: 'address',
+            name: '',
+            type: 'address',
+          },
+        ],
+        stateMutability: 'view',
+        type: 'function',
+      },
+    ]
+
+    const serviceRegistry = await hre.ethers.getContractAt(
+      serviceRegistryAbi,
+      serviceRegistryAddress,
+      config.signer,
+    )
+
+    const operationExecutorAddress = await serviceRegistry.getRegisteredService(
+      CONTRACT_NAMES.common.OPERATION_EXECUTOR,
+    )
+
+    const swapAddress = await serviceRegistry.getRegisteredService(CONTRACT_NAMES.common.SWAP)
+
+    const mainnetAddresses = {
+      DAI: ADDRESSES.main.DAI,
+      ETH: ADDRESSES.main.ETH,
+      WETH: ADDRESSES.main.WETH,
+      STETH: ADDRESSES.main.STETH,
+      WBTC: ADDRESSES.main.WBTC,
+      USDC: ADDRESSES.main.USDC,
+      chainlinkEthUsdPriceFeed: ADDRESSES.main.chainlinkEthUsdPriceFeed,
+      aavePriceOracle: ADDRESSES.main.aavePriceOracle,
+      aaveLendingPool: ADDRESSES.main.aave.MainnetLendingPool,
+      operationExecutor: operationExecutorAddress,
+      aaveProtocolDataProvider: ADDRESSES.main.aave.DataProvider,
+      accountFactory: '0xF7B75183A2829843dB06266c114297dfbFaeE2b6',
+    }
+
+    const swapData = taskArgs.usefallbackswap ? oneInchCallMock() : getOneInchCall(swapAddress)
+
+    const [proxy1, vaultId1] = await createDPMAccount(mainnetAddresses.accountFactory, config)
+    const [proxy2, vaultId2] = await createDPMAccount(mainnetAddresses.accountFactory, config)
+    const [proxy3, vaultId3] = await createDPMAccount(mainnetAddresses.accountFactory, config)
+
+    if (proxy1 === undefined || proxy2 === undefined || proxy3 === undefined) {
+      throw new Error(`Can't create DPM accounts`)
+    }
+
+    console.log(`DPM Created: ${proxy1}. VaultId: ${vaultId1}`)
+    console.log(`DPM Created: ${proxy2}. VaultId: ${vaultId2}`)
+    console.log(`DPM Created: ${proxy3}. VaultId: ${vaultId3}`)
+
+    const dependencies: StrategiesDependencies = {
+      addresses: mainnetAddresses,
+      provider: config.provider,
+      getSwapData: swapData,
+      user: config.address,
+      contracts: {
+        operationExecutor: new config.ethers.Contract(
+          operationExecutorAddress,
+          [
+            {
+              inputs: [
+                {
+                  components: [
+                    {
+                      internalType: 'bytes32',
+                      name: 'targetHash',
+                      type: 'bytes32',
+                    },
+                    {
+                      internalType: 'bytes',
+                      name: 'callData',
+                      type: 'bytes',
+                    },
+                    {
+                      internalType: 'bool',
+                      name: 'skipped',
+                      type: 'bool',
+                    },
+                  ],
+                  internalType: 'struct Call[]',
+                  name: 'calls',
+                  type: 'tuple[]',
+                },
+                {
+                  internalType: 'string',
+                  name: 'operationName',
+                  type: 'string',
+                },
+              ],
+              name: 'executeOp',
+              outputs: [],
+              stateMutability: 'payable',
+              type: 'function',
+            },
+          ],
+          config.provider,
+        ),
+      },
+    }
+
+    const positionDetails1 = await createEthUsdcMultiplyAAVEPosition(
+      proxy1,
+      true,
+      dependencies,
+      config,
+    )
+
+    console.log(
+      `Position created: ${positionDetails1.strategy} with proxy: ${positionDetails1.proxy}`,
+    )
+
+    const positionDetails2 = await createStEthUsdcMultiplyAAVEPosition(
+      proxy2,
+      true,
+      dependencies,
+      config,
+      getToken,
+    )
+
+    console.log(
+      `Position created: ${positionDetails2.strategy} with proxy: ${positionDetails2.proxy}`,
+    )
+
+    const positionDetails3 = await createWbtcUsdcMultiplyAAVEPosition(
+      proxy3,
+      true,
+      dependencies,
+      config,
+      getToken,
+    )
+
+    console.log(
+      `Position created: ${positionDetails3.strategy} with proxy: ${positionDetails3.proxy}`,
+    )
+  })

--- a/test/fixtures/factories/createDPMAccount.ts
+++ b/test/fixtures/factories/createDPMAccount.ts
@@ -2,25 +2,16 @@ import { ethers } from 'ethers'
 
 import accountFactoryAbi from '../../../abi/account-factory.json'
 import { RuntimeConfig } from '../../../helpers/types/common'
-import { AccountFactory } from '../../../typechain/contracts/test/dpm'
 
 export async function createDPMAccount(
   accountFactoryAddress: string,
   { signer }: RuntimeConfig,
-): Promise<string | undefined> {
-  const accountFactory = new ethers.Contract(
-    accountFactoryAddress,
-    accountFactoryAbi,
-    signer,
-  ) as AccountFactory
+): Promise<[string | undefined, number | undefined]> {
+  const accountFactory = new ethers.Contract(accountFactoryAddress, accountFactoryAbi, signer)
 
   const tx = await accountFactory.functions['createAccount()']()
   const receipt = await tx.wait()
 
-  // const eventSignature = ethers.utils.hexlify(
-  //   ethers.utils.keccak256(ethers.utils.toUtf8Bytes('AccountCreated(address,address,uint256)')),
-  // )
-
   // eslint-disable-next-line
-  return receipt.events![1].args!.proxy
+  return [receipt.events![1].args!.proxy, receipt.events![1].args!.vaultId]
 }

--- a/test/fixtures/factories/createStEthUsdcMultiplyAAVEPosition.ts
+++ b/test/fixtures/factories/createStEthUsdcMultiplyAAVEPosition.ts
@@ -3,44 +3,50 @@ import BigNumber from 'bignumber.js'
 
 import { executeThroughDPMProxy, executeThroughProxy } from '../../../helpers/deploy'
 import { RuntimeConfig } from '../../../helpers/types/common'
-import { amountToWei } from '../../../helpers/utils'
+import { amountToWei, approve } from '../../../helpers/utils'
 import { AavePositionStrategy, PositionDetails, StrategiesDependencies } from '../types'
 import { OpenPositionTypes } from './openPositionTypes'
 
-async function getStEthEthEarnAAVEPosition(dependencies: OpenPositionTypes[1]) {
-  const debtToken = { symbol: 'ETH' as const, precision: 18 }
-  const collateralToken = { symbol: 'STETH' as const, precision: 18 }
+const debtToken = { symbol: 'USDC' as const, precision: 6 }
+const collateralToken = { symbol: 'STETH' as const, precision: 18 }
+const amountInBaseUnit = amountToWei(new BigNumber(10), collateralToken.precision)
 
+async function getStEthUsdcMultiplyAAVEPosition(dependencies: OpenPositionTypes[1]) {
   const args: OpenPositionTypes[0] = {
     collateralToken: collateralToken,
     debtToken: debtToken,
     slippage: new BigNumber(0.1),
     depositedByUser: {
-      debtToken: {
-        amountInBaseUnit: amountToWei(new BigNumber(10), debtToken.precision),
+      collateralToken: {
+        amountInBaseUnit,
       },
     },
     multiple: new BigNumber(1.5),
-    positionType: 'Earn',
+    positionType: 'Multiply',
     collectSwapFeeFrom: 'sourceToken',
   }
 
   return await strategies.aave.open(args, dependencies)
 }
 
-export async function createStEthEthEarnAAVEPosition(
+export async function createStEthUsdcMultiplyAAVEPosition(
   proxy: string,
   isDPM: boolean,
   dependencies: StrategiesDependencies,
   config: RuntimeConfig,
+  getTokens: (symbol: 'STETH', amount: string) => Promise<boolean>,
 ): Promise<PositionDetails> {
-  const strategy: AavePositionStrategy = 'STETH/ETH Earn'
+  const strategy: AavePositionStrategy = 'STETH/USDC Multiply'
 
-  const stEthEthEarnAAVEPosition = await getStEthEthEarnAAVEPosition({
+  const position = await getStEthUsdcMultiplyAAVEPosition({
     ...dependencies,
     isDPMProxy: isDPM,
     proxy: proxy,
   })
+
+  await getTokens('STETH', amountInBaseUnit.toString())
+
+  await approve(dependencies.addresses.STETH, proxy, amountInBaseUnit, config, false)
 
   const proxyFunction = isDPM ? executeThroughDPMProxy : executeThroughProxy
 
@@ -49,15 +55,12 @@ export async function createStEthEthEarnAAVEPosition(
     {
       address: dependencies.contracts.operationExecutor.address,
       calldata: dependencies.contracts.operationExecutor.interface.encodeFunctionData('executeOp', [
-        stEthEthEarnAAVEPosition.transaction.calls,
-        stEthEthEarnAAVEPosition.transaction.operationName,
+        position.transaction.calls,
+        position.transaction.operationName,
       ]),
     },
     config.signer,
-    amountToWei(
-      new BigNumber(10),
-      stEthEthEarnAAVEPosition.simulation.position.debt.precision,
-    ).toString(),
+    '0',
   )
 
   if (!status) {
@@ -69,8 +72,8 @@ export async function createStEthEthEarnAAVEPosition(
     getPosition: async () => {
       return await strategies.aave.view(
         {
-          collateralToken: { symbol: 'STETH' as const, precision: 18 },
-          debtToken: { symbol: 'ETH' as const, precision: 18 },
+          collateralToken,
+          debtToken,
           proxy: proxy,
         },
         {
@@ -82,6 +85,6 @@ export async function createStEthEthEarnAAVEPosition(
         },
       )
     },
-    strategy: 'STETH/ETH Earn',
+    strategy,
   }
 }

--- a/test/fixtures/factories/index.ts
+++ b/test/fixtures/factories/index.ts
@@ -1,2 +1,5 @@
 export { createDPMAccount } from './createDPMAccount'
+export { createEthUsdcMultiplyAAVEPosition } from './createEthUsdcMultiplyAAVEPosition'
 export { createStEthEthEarnAAVEPosition } from './createStEthEthEarnAAVEPosition'
+export { createStEthUsdcMultiplyAAVEPosition } from './createStEthUsdcMultiplyAAVEPosition'
+export { createWbtcUsdcMultiplyAAVEPosition } from './createWbtcUsdcMultiplyAAVEPosition'

--- a/test/fixtures/factories/openPositionTypes.ts
+++ b/test/fixtures/factories/openPositionTypes.ts
@@ -1,0 +1,2 @@
+import { strategies } from '@oasisdex/oasis-actions'
+export type OpenPositionTypes = Parameters<typeof strategies.aave.open>

--- a/test/fixtures/types/systemWithAAVEPosition.ts
+++ b/test/fixtures/types/systemWithAAVEPosition.ts
@@ -1,13 +1,15 @@
-import { RuntimeConfig } from '../../../helpers/types/common'
+import { AAVETokensToGet } from '../../../helpers/aave'
+import { HardhatRuntimeConfig } from '../../../helpers/types/common'
 import { deploySystem } from '../../deploySystem'
 import { AavePositionStrategy, PositionDetails } from './positionDetails'
 import { StrategiesDependencies } from './strategiesDependencies'
 
 export type SystemWithAAVEPosition = {
-  config: RuntimeConfig
+  config: HardhatRuntimeConfig
   system: Awaited<ReturnType<typeof deploySystem>>['system']
   registry: Awaited<ReturnType<typeof deploySystem>>['registry']
   dpmPositions: Partial<Record<AavePositionStrategy, PositionDetails>>
   dsProxyPosition: PositionDetails
   strategiesDependencies: StrategiesDependencies
+  getTokens: (symbol: AAVETokensToGet, amount: string) => Promise<boolean>
 }


### PR DESCRIPTION
# Changes
- Creating test multiply positions
- Method to get token to test account
- new account factory, account impl, account guard
- reverted `SendToken.sol` to actual blockchain implementation.
- New version of the library.
- Withdrawing is using `ReturnFunds` right now.