### PR TITLE
Fix health factor on IPosition

### DIFF
--- a/packages/oasis-actions/src/helpers/calculations/Position.ts
+++ b/packages/oasis-actions/src/helpers/calculations/Position.ts
@@ -170,10 +170,10 @@ export class Position implements IPosition {
   }
 
   public get healthFactor() {
-    return this.collateral.amount
+    return this.collateral.normalisedAmount
       .times(this.category.liquidationThreshold)
       .times(this._oraclePriceForCollateralDebtExchangeRate)
-      .div(this.debt.amount)
+      .div(this.debt.normalisedAmount)
   }
 
   public get liquidationPrice() {

--- a/packages/oasis-actions/src/helpers/calculations/Position.ts
+++ b/packages/oasis-actions/src/helpers/calculations/Position.ts
@@ -101,6 +101,7 @@ export interface IPosition extends IBasePosition {
   minConfigurableRiskRatio: (marketPriceAccountingForSlippage: BigNumber) => IRiskRatio
   riskRatio: IRiskRatio
   healthFactor: BigNumber
+  relativeCollateralPriceMovementUntilLiquidation: BigNumber
   liquidationPrice: BigNumber
   maxDebtToBorrow: BigNumber
   maxCollateralToWithdraw: BigNumber
@@ -174,6 +175,12 @@ export class Position implements IPosition {
       .times(this.category.liquidationThreshold)
       .times(this._oraclePriceForCollateralDebtExchangeRate)
       .div(this.debt.normalisedAmount)
+  }
+
+  // returns the percentage amount (as decimal) that the collateral price would have to
+  // move relative to debt for the position to be at risk of liquidation.
+  public get relativeCollateralPriceMovementUntilLiquidation() {
+    return ONE.minus(ONE.div(this.healthFactor))
   }
 
   public get liquidationPrice() {


### PR DESCRIPTION
Relates to https://app.shortcut.com/oazo-apps/story/7260/bug-100-price-movement-is-incorrect

- Updates health factor to handle tokens with different precisions.
- Adds a new value to IPosition: `relativeCollateralPriceMovementUntilLiquidation`
- Publishes new package version

Related PR: https://github.com/OasisDEX/oasis-borrow/pull/1875