### PR TITLE
Fix: Library handles fee collection not client

### DIFF
--- a/packages/oasis-actions/package.json
+++ b/packages/oasis-actions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oasisdex/oasis-actions",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "main": "lib/src/index.js",
   "typings": "lib/src/index.d.ts",
   "scripts": {

--- a/packages/oasis-actions/package.json
+++ b/packages/oasis-actions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oasisdex/oasis-actions",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "main": "lib/src/index.js",
   "typings": "lib/src/index.d.ts",
   "scripts": {

--- a/packages/oasis-actions/package.json
+++ b/packages/oasis-actions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oasisdex/oasis-actions",
-  "version": "0.1.7",
+  "version": "0.1.10",
   "main": "lib/src/index.js",
   "typings": "lib/src/index.d.ts",
   "scripts": {

--- a/packages/oasis-actions/src/config/acceptedFeeTokensConfig.ts
+++ b/packages/oasis-actions/src/config/acceptedFeeTokensConfig.ts
@@ -1,0 +1,12 @@
+/* Selection of token symbols and addresses that we're happy to accept as a fee */
+import { ADDRESSES } from '../helpers/addresses'
+
+export const acceptedTokenSymbols = ['ETH', 'WETH', 'USDT', 'USDC', 'WBTC', 'DAI']
+export const acceptedTokenAddresses = [
+  ADDRESSES.main.ETH,
+  ADDRESSES.main.WETH,
+  ADDRESSES.main.USDT,
+  ADDRESSES.main.USDC,
+  ADDRESSES.main.WBTC,
+  ADDRESSES.main.DAI,
+]

--- a/packages/oasis-actions/src/config/acceptedFeeTokensConfig.ts
+++ b/packages/oasis-actions/src/config/acceptedFeeTokensConfig.ts
@@ -1,12 +1,29 @@
 /* Selection of token symbols and addresses that we're happy to accept as a fee */
 import { ADDRESSES } from '../helpers/addresses'
 
-export const acceptedTokenSymbols = ['ETH', 'WETH', 'USDT', 'USDC', 'WBTC', 'DAI']
-export const acceptedTokenAddresses = [
-  ADDRESSES.main.ETH,
-  ADDRESSES.main.WETH,
-  ADDRESSES.main.USDT,
-  ADDRESSES.main.USDC,
-  ADDRESSES.main.WBTC,
-  ADDRESSES.main.DAI,
+export const acceptedTokens = [
+  {
+    symbol: 'USDC',
+    address: ADDRESSES.main.USDC,
+  },
+  {
+    symbol: 'DAI',
+    address: ADDRESSES.main,
+  },
+  {
+    symbol: 'WETH',
+    address: ADDRESSES.main.WETH,
+  },
+  {
+    symbol: 'ETH',
+    address: ADDRESSES.main.ETH,
+  },
+  {
+    symbol: 'STETH',
+    address: ADDRESSES.main.STETH,
+  },
+  {
+    symbol: 'WBTC',
+    address: ADDRESSES.main.WBTC,
+  },
 ]

--- a/packages/oasis-actions/src/helpers/acceptedFeeToken.ts
+++ b/packages/oasis-actions/src/helpers/acceptedFeeToken.ts
@@ -11,7 +11,7 @@ interface Props {
  * Prefers sourceToken over targetToken
  * Accepts args as either a token symbol or in address format
  */
-export function acceptedFeeToken({ fromToken, toToken }: Props) {
+export function acceptedFeeToken({ fromToken, toToken }: Props): 'sourceToken' | 'targetToken' {
   const fromTokenAcceptedIndex = acceptedTokens.findIndex(
     acceptedToken => fromToken === acceptedToken.symbol || fromToken === acceptedToken.address,
   )

--- a/packages/oasis-actions/src/helpers/acceptedFeeToken.ts
+++ b/packages/oasis-actions/src/helpers/acceptedFeeToken.ts
@@ -1,0 +1,38 @@
+import { ADDRESSES } from './addresses'
+
+/**
+ * Prefers sourceToken over targetToken
+ * Accepts args as either a token symbol or eth address
+ * @param sourceToken
+ * @param targetToken
+ */
+type TokenSymbolOrAddress = string
+
+export function acceptedFeeToken(
+  sourceToken: TokenSymbolOrAddress,
+  targetToken: TokenSymbolOrAddress,
+) {
+  if (acceptSourceToken(sourceToken)) return 'sourceToken'
+  if (acceptTargetToken(targetToken)) return 'targetToken'
+
+  const fallbackTokenType = 'sourceToken'
+  return fallbackTokenType
+}
+
+function acceptSourceToken(sourceToken: TokenSymbolOrAddress) {
+  return acceptedTokenSymbols.includes(sourceToken) || acceptedTokenAddresses.includes(sourceToken)
+}
+
+function acceptTargetToken(targetToken: TokenSymbolOrAddress) {
+  return acceptedTokenSymbols.includes(targetToken) || acceptedTokenAddresses.includes(targetToken)
+}
+
+const acceptedTokenSymbols = ['ETH', 'WETH', 'USDT', 'USDC', 'WBTC', 'DAI']
+const acceptedTokenAddresses = [
+  ADDRESSES.main.ETH,
+  ADDRESSES.main.WETH,
+  ADDRESSES.main.USDT,
+  ADDRESSES.main.USDC,
+  ADDRESSES.main.WBTC,
+  ADDRESSES.main.DAI,
+]

--- a/packages/oasis-actions/src/helpers/acceptedFeeToken.ts
+++ b/packages/oasis-actions/src/helpers/acceptedFeeToken.ts
@@ -1,4 +1,4 @@
-import { ADDRESSES } from './addresses'
+import { acceptedTokenAddresses, acceptedTokenSymbols } from '../config/acceptedFeeTokensConfig'
 
 type TokenSymbolOrAddress = string
 
@@ -9,7 +9,7 @@ interface Props {
 
 /**
  * Prefers sourceToken over targetToken
- * Accepts args as either a token symbol or eth address
+ * Accepts args as either a token symbol or in address format
  */
 export function acceptedFeeToken({ fromToken, toToken }: Props) {
   if (acceptSourceToken(fromToken)) return 'sourceToken'
@@ -26,13 +26,3 @@ function acceptSourceToken(sourceToken: TokenSymbolOrAddress) {
 function acceptTargetToken(targetToken: TokenSymbolOrAddress) {
   return acceptedTokenSymbols.includes(targetToken) || acceptedTokenAddresses.includes(targetToken)
 }
-
-const acceptedTokenSymbols = ['ETH', 'WETH', 'USDT', 'USDC', 'WBTC', 'DAI']
-const acceptedTokenAddresses = [
-  ADDRESSES.main.ETH,
-  ADDRESSES.main.WETH,
-  ADDRESSES.main.USDT,
-  ADDRESSES.main.USDC,
-  ADDRESSES.main.WBTC,
-  ADDRESSES.main.DAI,
-]

--- a/packages/oasis-actions/src/helpers/acceptedFeeToken.ts
+++ b/packages/oasis-actions/src/helpers/acceptedFeeToken.ts
@@ -1,19 +1,19 @@
 import { ADDRESSES } from './addresses'
 
+type TokenSymbolOrAddress = string
+
+interface Props {
+  fromToken: TokenSymbolOrAddress
+  toToken: TokenSymbolOrAddress
+}
+
 /**
  * Prefers sourceToken over targetToken
  * Accepts args as either a token symbol or eth address
- * @param sourceToken
- * @param targetToken
  */
-type TokenSymbolOrAddress = string
-
-export function acceptedFeeToken(
-  sourceToken: TokenSymbolOrAddress,
-  targetToken: TokenSymbolOrAddress,
-) {
-  if (acceptSourceToken(sourceToken)) return 'sourceToken'
-  if (acceptTargetToken(targetToken)) return 'targetToken'
+export function acceptedFeeToken({ fromToken, toToken }: Props) {
+  if (acceptSourceToken(fromToken)) return 'sourceToken'
+  if (acceptTargetToken(toToken)) return 'targetToken'
 
   const fallbackTokenType = 'sourceToken'
   return fallbackTokenType

--- a/packages/oasis-actions/src/helpers/acceptedFeeToken.ts
+++ b/packages/oasis-actions/src/helpers/acceptedFeeToken.ts
@@ -1,4 +1,4 @@
-import { acceptedTokenAddresses, acceptedTokenSymbols } from '../config/acceptedFeeTokensConfig'
+import { acceptedTokens } from '../config/acceptedFeeTokensConfig'
 
 type TokenSymbolOrAddress = string
 
@@ -12,17 +12,19 @@ interface Props {
  * Accepts args as either a token symbol or in address format
  */
 export function acceptedFeeToken({ fromToken, toToken }: Props) {
-  if (acceptSourceToken(fromToken)) return 'sourceToken'
-  if (acceptTargetToken(toToken)) return 'targetToken'
+  const fromTokenAcceptedIndex = acceptedTokens.findIndex(
+    acceptedToken => fromToken === acceptedToken.symbol || fromToken === acceptedToken.address,
+  )
+  const toTokenAcceptedIndex = acceptedTokens.findIndex(
+    acceptedToken => toToken === acceptedToken.symbol || toToken === acceptedToken.address,
+  )
 
-  const fallbackTokenType = 'sourceToken'
-  return fallbackTokenType
-}
+  if (fromTokenAcceptedIndex === -1 && toTokenAcceptedIndex === -1) {
+    console.warn('Both source and target tokens are not in the accepted fee tokens list')
+    const fallbackTokenType = 'sourceToken'
+    return fallbackTokenType
+  }
 
-function acceptSourceToken(sourceToken: TokenSymbolOrAddress) {
-  return acceptedTokenSymbols.includes(sourceToken) || acceptedTokenAddresses.includes(sourceToken)
-}
-
-function acceptTargetToken(targetToken: TokenSymbolOrAddress) {
-  return acceptedTokenSymbols.includes(targetToken) || acceptedTokenAddresses.includes(targetToken)
+  /* Select the token to take the fee from based on priority order */
+  return fromTokenAcceptedIndex < toTokenAcceptedIndex ? 'sourceToken' : 'targetToken'
 }

--- a/packages/oasis-actions/src/strategies/aave/adjust.ts
+++ b/packages/oasis-actions/src/strategies/aave/adjust.ts
@@ -10,14 +10,14 @@ import { RiskRatio } from '../../helpers/calculations/RiskRatio'
 import { ONE, TYPICAL_PRECISION, UNUSED_FLASHLOAN_AMOUNT, ZERO } from '../../helpers/constants'
 import * as operations from '../../operations'
 import { AAVEStrategyAddresses } from '../../operations/aave/addresses'
-import { AAVETokens } from '../types/aave/tokens'
-import { IOperation } from '../types/IOperation'
 import {
+  IOperation,
+  IPositionTransition,
   IPositionTransitionArgs,
   IPositionTransitionDependencies,
-} from '../types/IPositionRepository'
-import { IPositionTransition } from '../types/IPositionTransition'
-import { SwapData } from '../types/SwapData'
+  SwapData,
+} from '../types'
+import { AAVETokens } from '../types/aave'
 import { getAAVETokenAddresses } from './getAAVETokenAddresses'
 
 const FEE = 20

--- a/packages/oasis-actions/src/strategies/aave/adjust.ts
+++ b/packages/oasis-actions/src/strategies/aave/adjust.ts
@@ -3,6 +3,7 @@ import { ethers } from 'ethers'
 
 import aavePriceOracleABI from '../../abi/aavePriceOracle.json'
 import { amountFromWei, amountToWei } from '../../helpers'
+import { acceptedFeeToken } from '../../helpers/acceptedFeeToken'
 import { ADDRESSES } from '../../helpers/addresses'
 import { IBaseSimulatedTransition, IPosition, Position } from '../../helpers/calculations/Position'
 import { RiskRatio } from '../../helpers/calculations/RiskRatio'
@@ -50,6 +51,7 @@ export async function adjust(
   const fromTokenAddress = isIncreasingRisk ? debtTokenAddress : collateralTokenAddress
   const toTokenAddress = isIncreasingRisk ? collateralTokenAddress : debtTokenAddress
   const toToken = isIncreasingRisk ? args.collateralToken : args.debtToken
+  const collectFeeFrom = acceptedFeeToken(fromToken.symbol, toToken.symbol)
   const estimatedSwapAmount = amountToWei(new BigNumber(1), fromToken.precision)
 
   const aavePriceOracle = new ethers.Contract(
@@ -113,7 +115,6 @@ export async function adjust(
     currentPosition.category,
   )
 
-  const collectFeeFrom = args.collectSwapFeeFrom ?? 'sourceToken'
   const quoteMarketPriceExpectedByMaths = isIncreasingRisk
     ? quoteMarketPrice
     : ONE.div(quoteMarketPrice)

--- a/packages/oasis-actions/src/strategies/aave/adjust.ts
+++ b/packages/oasis-actions/src/strategies/aave/adjust.ts
@@ -51,7 +51,7 @@ export async function adjust(
   const fromTokenAddress = isIncreasingRisk ? debtTokenAddress : collateralTokenAddress
   const toTokenAddress = isIncreasingRisk ? collateralTokenAddress : debtTokenAddress
   const toToken = isIncreasingRisk ? args.collateralToken : args.debtToken
-  const collectFeeFrom = acceptedFeeToken(fromToken.symbol, toToken.symbol)
+  const collectFeeFrom = acceptedFeeToken({ fromToken: fromToken.symbol, toToken: toToken.symbol })
   const estimatedSwapAmount = amountToWei(new BigNumber(1), fromToken.precision)
 
   const aavePriceOracle = new ethers.Contract(

--- a/packages/oasis-actions/src/strategies/aave/close.ts
+++ b/packages/oasis-actions/src/strategies/aave/close.ts
@@ -48,6 +48,7 @@ export async function close(
     fromToken: args.collateralToken.symbol,
     toToken: args.debtToken.symbol,
   })
+
   const swapAmountBeforeFees = args.collateralAmountLockedInProtocolInWei
   const fee = calculateFee(swapAmountBeforeFees, FEE, FEE_BASE)
 
@@ -124,6 +125,15 @@ export async function close(
 
   const flags = { requiresFlashloan: true, isIncreasingRisk: false }
 
+  const postSwapFee =
+    collectFeeFrom === 'targetToken'
+      ? calculateFee(
+          dependencies.currentPosition.collateral.amount.div(actualMarketPriceWithSlippage),
+          FEE,
+          FEE_BASE,
+        )
+      : ZERO
+
   return {
     transaction: {
       calls: operation.calls,
@@ -138,7 +148,7 @@ export async function close(
       flags: flags,
       swap: {
         ...swapData,
-        tokenFee: fee,
+        tokenFee: collectFeeFrom === 'sourceToken' ? fee : postSwapFee,
         collectFeeFrom,
         sourceToken: {
           symbol: args.collateralToken.symbol,

--- a/packages/oasis-actions/src/strategies/aave/close.ts
+++ b/packages/oasis-actions/src/strategies/aave/close.ts
@@ -50,7 +50,8 @@ export async function close(
   })
 
   const swapAmountBeforeFees = args.collateralAmountLockedInProtocolInWei
-  const fee = calculateFee(swapAmountBeforeFees, FEE, FEE_BASE)
+  const fee =
+    collectFeeFrom === 'sourceToken' ? calculateFee(swapAmountBeforeFees, FEE, FEE_BASE) : ZERO
 
   const swapAmountAfterFees = swapAmountBeforeFees.minus(
     collectFeeFrom === 'sourceToken' ? fee : ZERO,
@@ -148,7 +149,7 @@ export async function close(
       flags: flags,
       swap: {
         ...swapData,
-        tokenFee: collectFeeFrom === 'sourceToken' ? fee : postSwapFee,
+        tokenFee: fee.plus(postSwapFee),
         collectFeeFrom,
         sourceToken: {
           symbol: args.collateralToken.symbol,

--- a/packages/oasis-actions/src/strategies/aave/close.ts
+++ b/packages/oasis-actions/src/strategies/aave/close.ts
@@ -4,6 +4,7 @@ import { ethers } from 'ethers'
 import aavePriceOracleABI from '../../abi/aavePriceOracle.json'
 import aaveProtocolDataProviderABI from '../../abi/aaveProtocolDataProvider.json'
 import { amountFromWei, amountToWei, calculateFee } from '../../helpers'
+import { acceptedFeeToken } from '../../helpers/acceptedFeeToken'
 import { ADDRESSES } from '../../helpers/addresses'
 import { Position } from '../../helpers/calculations/Position'
 import { FLASHLOAN_SAFETY_MARGIN, ONE, TYPICAL_PRECISION, ZERO } from '../../helpers/constants'
@@ -43,7 +44,8 @@ export async function close(
 
   const FEE = 20
   const FEE_BASE = 10000
-  const collectFeeFrom = args.collectSwapFeeFrom ?? 'sourceToken'
+  const collectFeeFrom =
+    acceptedFeeToken(args.collateralToken.symbol, args.debtToken.symbol) || 'sourceToken'
   const swapAmountBeforeFees = args.collateralAmountLockedInProtocolInWei
   const fee = calculateFee(swapAmountBeforeFees, FEE, FEE_BASE)
 
@@ -135,7 +137,7 @@ export async function close(
       swap: {
         ...swapData,
         tokenFee: fee,
-        collectFeeFrom: args.collectSwapFeeFrom ?? 'sourceToken',
+        collectFeeFrom,
         sourceToken: {
           symbol: args.collateralToken.symbol,
           precision: args.collateralToken.precision ?? TYPICAL_PRECISION,

--- a/packages/oasis-actions/src/strategies/aave/close.ts
+++ b/packages/oasis-actions/src/strategies/aave/close.ts
@@ -44,8 +44,10 @@ export async function close(
 
   const FEE = 20
   const FEE_BASE = 10000
-  const collectFeeFrom =
-    acceptedFeeToken(args.collateralToken.symbol, args.debtToken.symbol) || 'sourceToken'
+  const collectFeeFrom = acceptedFeeToken({
+    fromToken: args.collateralToken.symbol,
+    toToken: args.debtToken.symbol,
+  })
   const swapAmountBeforeFees = args.collateralAmountLockedInProtocolInWei
   const fee = calculateFee(swapAmountBeforeFees, FEE, FEE_BASE)
 

--- a/packages/oasis-actions/src/strategies/aave/getAAVETokenAddresses.ts
+++ b/packages/oasis-actions/src/strategies/aave/getAAVETokenAddresses.ts
@@ -1,21 +1,6 @@
-import { ADDRESSES } from '../../helpers/addresses'
 import { AAVEStrategyAddresses } from '../../operations/aave/addresses'
 import { AAVETokens } from '../types/aave/tokens'
 import { IPositionTransitionArgs } from '../types/IPositionRepository'
-
-export const mainnetAAVEAddresses = {
-  DAI: ADDRESSES.main.DAI,
-  ETH: ADDRESSES.main.ETH,
-  WETH: ADDRESSES.main.WETH,
-  STETH: ADDRESSES.main.STETH,
-  WBTC: ADDRESSES.main.WBTC,
-  USDC: ADDRESSES.main.USDC,
-  chainlinkEthUsdPriceFeed: ADDRESSES.main.chainlinkEthUsdPriceFeed,
-  aaveProtocolDataProvider: ADDRESSES.main.aave.DataProvider,
-  aavePriceOracle: ADDRESSES.main.aavePriceOracle,
-  aaveLendingPool: ADDRESSES.main.aave.MainnetLendingPool,
-  operationExecutor: ADDRESSES.main.operationExecutor,
-}
 
 export const getAAVETokenAddresses = (
   args: {

--- a/packages/oasis-actions/src/strategies/aave/open.ts
+++ b/packages/oasis-actions/src/strategies/aave/open.ts
@@ -157,7 +157,10 @@ export async function open(
   // EG STETH/ETH divided by USDC/ETH = STETH/USDC
   const oracle = aaveCollateralTokenPriceInEth.div(aaveDebtTokenPriceInEth)
 
-  const collectFeeFrom = acceptedFeeToken(args.debtToken.symbol, args.collateralToken.symbol)
+  const collectFeeFrom = acceptedFeeToken({
+    fromToken: args.debtToken.symbol,
+    toToken: args.collateralToken.symbol,
+  })
   const target = currentPosition.adjustToTargetRiskRatio(
     new RiskRatio(multiple, RiskRatio.TYPE.MULITPLE),
     {

--- a/packages/oasis-actions/src/strategies/aave/open.ts
+++ b/packages/oasis-actions/src/strategies/aave/open.ts
@@ -4,6 +4,7 @@ import { ethers, providers } from 'ethers'
 import aavePriceOracleABI from '../../abi/aavePriceOracle.json'
 import aaveProtocolDataProviderABI from '../../abi/aaveProtocolDataProvider.json'
 import { amountFromWei, amountToWei } from '../../helpers'
+import { acceptedFeeToken } from '../../helpers/acceptedFeeToken'
 import { ADDRESSES } from '../../helpers/addresses'
 import { Position } from '../../helpers/calculations/Position'
 import { RiskRatio } from '../../helpers/calculations/RiskRatio'
@@ -27,7 +28,6 @@ interface OpenPositionArgs {
   positionType: PositionType
   collateralToken: { symbol: AAVETokens; precision?: number }
   debtToken: { symbol: AAVETokens; precision?: number }
-  collectSwapFeeFrom?: 'sourceToken' | 'targetToken'
 }
 
 interface OpenPositionDependencies {
@@ -157,7 +157,7 @@ export async function open(
   // EG STETH/ETH divided by USDC/ETH = STETH/USDC
   const oracle = aaveCollateralTokenPriceInEth.div(aaveDebtTokenPriceInEth)
 
-  const collectFeeFrom = args.collectSwapFeeFrom ?? 'sourceToken'
+  const collectFeeFrom = acceptedFeeToken(args.debtToken.symbol, args.collateralToken.symbol)
   const target = currentPosition.adjustToTargetRiskRatio(
     new RiskRatio(multiple, RiskRatio.TYPE.MULITPLE),
     {

--- a/packages/oasis-actions/src/strategies/aave/paybackWithdraw.ts
+++ b/packages/oasis-actions/src/strategies/aave/paybackWithdraw.ts
@@ -11,6 +11,7 @@ import {
 import { AAVETokens } from '../types/aave'
 import * as operations from './../../operations'
 import { getAAVETokenAddresses } from './getAAVETokenAddresses'
+
 export async function paybackWithdraw(
   args: IBasePositionTransitionArgs<AAVETokens> & WithWithdrawCollateral & WithPaybackDebt,
   dependencies: IPositionTransitionDependencies<AAVEStrategyAddresses>,

--- a/packages/oasis-actions/src/strategies/types/IPositionRepository.ts
+++ b/packages/oasis-actions/src/strategies/types/IPositionRepository.ts
@@ -8,7 +8,6 @@ export interface IBasePositionTransitionArgs<Tokens> {
   slippage: BigNumber
   collateralToken: { symbol: Tokens; precision?: number }
   debtToken: { symbol: Tokens; precision?: number }
-  collectSwapFeeFrom?: 'sourceToken' | 'targetToken'
 }
 
 type WithDeposit = {

--- a/test/aave/Adjust.test.ts
+++ b/test/aave/Adjust.test.ts
@@ -59,7 +59,7 @@ describe(`Strategy | AAVE | Adjust Position`, async function () {
     aaveDataProvider = new Contract(ADDRESSES.main.aave.DataProvider, AAVEDataProviderABI, provider)
   })
 
-  describe('On forked chain', () => {
+  describe('[Uniswap]', () => {
     const multiple = new BigNumber(2)
     const slippage = new BigNumber(0.1)
 

--- a/test/aave/Adjust.test.ts
+++ b/test/aave/Adjust.test.ts
@@ -3,17 +3,17 @@ import {
   AAVETokens,
   ADDRESSES,
   IPosition,
+  IPositionTransition,
   ONE,
   OPERATION_NAMES,
   Position,
   strategies,
   TYPICAL_PRECISION,
   ZERO,
-} from '@oasisdex/oasis-actions'
-import aavePriceOracleABI from '@oasisdex/oasis-actions/lib/src/abi/aavePriceOracle.json'
-import { amountFromWei } from '@oasisdex/oasis-actions/lib/src/helpers'
-import { PositionType } from '@oasisdex/oasis-actions/lib/src/strategies/types/PositionType'
-import { IPositionTransition } from '@oasisdex/oasis-actions/src'
+} from '@oasisdex/oasis-actions/src'
+import aavePriceOracleABI from '@oasisdex/oasis-actions/src/abi/aavePriceOracle.json'
+import { amountFromWei } from '@oasisdex/oasis-actions/src/helpers'
+import { PositionType } from '@oasisdex/oasis-actions/src/strategies/types/PositionType'
 import BigNumber from 'bignumber.js'
 import { expect } from 'chai'
 import { loadFixture } from 'ethereum-waffle'
@@ -31,6 +31,7 @@ import { oneInchCallMock } from '../../helpers/swap/OneInchCallMock'
 import { swapUniswapTokens } from '../../helpers/swap/uniswap'
 import { RuntimeConfig } from '../../helpers/types/common'
 import { amountToWei, balanceOf } from '../../helpers/utils'
+import { acceptedFeeToken } from '../../packages/oasis-actions/src/helpers/acceptedFeeToken'
 import { mainnetAddresses } from '../addresses'
 import { testBlockNumber } from '../config'
 import { tokens } from '../constants'
@@ -86,8 +87,6 @@ describe(`Strategy | AAVE | Adjust Position`, async function () {
       adjustToMultiple: BigNumber,
       mockMarketPriceOnOpen: BigNumber,
       mockMarketPriceOnAdjust: BigNumber,
-      isFeeFromSourceTokenOnOpen: boolean,
-      isFeeFromSourceTokenOnAdjust: boolean,
       user: string,
       positionType: PositionType,
       blockNumber?: number,
@@ -171,7 +170,6 @@ describe(`Strategy | AAVE | Adjust Position`, async function () {
             symbol: collateralToken.symbol,
             precision: collateralToken.precision,
           },
-          collectSwapFeeFrom: isFeeFromSourceTokenOnOpen ? 'sourceToken' : 'targetToken',
         },
         {
           isDPMProxy: false,
@@ -262,6 +260,7 @@ describe(`Strategy | AAVE | Adjust Position`, async function () {
 
       // Now adjust the position
       const isIncreasingRisk = adjustToMultiple.gte(positionAfterOpen.riskRatio.multiple)
+      const isDecreasingRisk = !isIncreasingRisk
       const positionTransition = await strategies.aave.adjust(
         {
           depositedByUser: {
@@ -275,7 +274,6 @@ describe(`Strategy | AAVE | Adjust Position`, async function () {
             symbol: collateralToken.symbol,
             precision: collateralToken.precision,
           },
-          collectSwapFeeFrom: isFeeFromSourceTokenOnAdjust ? 'sourceToken' : 'targetToken',
         },
         {
           isDPMProxy: false,
@@ -291,18 +289,15 @@ describe(`Strategy | AAVE | Adjust Position`, async function () {
         },
       )
 
+      // TODO: Will need updating to use new helper
       let isFeeFromDebtToken = true
-      if (isIncreasingRisk && isFeeFromSourceTokenOnAdjust) {
-        isFeeFromDebtToken = true
+      if (isIncreasingRisk) {
+        isFeeFromDebtToken =
+          acceptedFeeToken(debtToken.symbol, collateralToken.symbol) === 'sourceToken'
       }
-      if (isIncreasingRisk && !isFeeFromSourceTokenOnAdjust) {
-        isFeeFromDebtToken = false
-      }
-      if (!isIncreasingRisk && isFeeFromSourceTokenOnAdjust) {
-        isFeeFromDebtToken = false
-      }
-      if (!isIncreasingRisk && !isFeeFromSourceTokenOnAdjust) {
-        isFeeFromDebtToken = true
+      if (isDecreasingRisk) {
+        isFeeFromDebtToken =
+          acceptedFeeToken(collateralToken.symbol, debtToken.symbol) === 'targetToken'
       }
       const feeRecipientBalanceBeforeAdjust = await balanceOf(
         isFeeFromDebtToken ? debtToken.address : collateralToken.address,
@@ -427,8 +422,6 @@ describe(`Strategy | AAVE | Adjust Position`, async function () {
           adjustMultipleUp,
           new BigNumber(0.9759),
           new BigNumber(0.9759),
-          true,
-          true,
           userAddress,
           'Earn',
         )
@@ -483,7 +476,7 @@ describe(`Strategy | AAVE | Adjust Position`, async function () {
       const depositAmount = amountToWei(new BigNumber(1))
       const adjustMultipleUp = new BigNumber(3.5)
 
-      let feeRecipientWethBalanceBefore: BigNumber
+      let feeRecipientUSDCBalanceBefore: BigNumber
       let finalPosition: IPosition
 
       before(async () => {
@@ -507,8 +500,6 @@ describe(`Strategy | AAVE | Adjust Position`, async function () {
           adjustMultipleUp,
           new BigNumber(1351),
           new BigNumber(1351),
-          true,
-          true,
           userAddress,
           'Multiply',
         )
@@ -516,7 +507,7 @@ describe(`Strategy | AAVE | Adjust Position`, async function () {
         openTxStatus = setup.openTxStatus
         positionTransition = setup.positionTransition
         finalPosition = setup.finalPosition
-        feeRecipientWethBalanceBefore = setup.feeRecipientBalanceBefore
+        feeRecipientUSDCBalanceBefore = setup.feeRecipientBalanceBefore
       })
 
       it('Open Tx should pass', () => {
@@ -536,13 +527,13 @@ describe(`Strategy | AAVE | Adjust Position`, async function () {
       })
 
       it('Should collect fee', async () => {
-        const feeRecipientWETHBalanceAfter = await balanceOf(
+        const feeRecipientUSDCBalanceAfter = await balanceOf(
           ADDRESSES.main.USDC,
           ADDRESSES.main.feeRecipient,
           { config },
         )
 
-        const actualUSDCFees = feeRecipientWETHBalanceAfter.minus(feeRecipientWethBalanceBefore)
+        const actualUSDCFees = feeRecipientUSDCBalanceAfter.minus(feeRecipientUSDCBalanceBefore)
 
         // Test for equivalence within slippage adjusted range when taking fee from target token
         expectToBe(
@@ -587,8 +578,6 @@ describe(`Strategy | AAVE | Adjust Position`, async function () {
           adjustMultipleUp,
           new BigNumber(20032),
           new BigNumber(20032),
-          true,
-          true,
           userAddress,
           'Multiply',
         )
@@ -667,8 +656,6 @@ describe(`Strategy | AAVE | Adjust Position`, async function () {
           adjustMultipleDown,
           new BigNumber(0.9759),
           ONE.div(new BigNumber(0.9759)),
-          true,
-          false,
           userAddress,
           'Multiply',
           15697000,
@@ -822,7 +809,6 @@ describe(`Strategy | AAVE | Adjust Position`, async function () {
             multiple: adjustToMultiple,
             debtToken,
             collateralToken,
-            collectSwapFeeFrom: 'sourceToken',
           },
           {
             isDPMProxy: false,
@@ -1042,7 +1028,6 @@ describe(`Strategy | AAVE | Adjust Position`, async function () {
             multiple: adjustDownToMultiple,
             debtToken,
             collateralToken,
-            collectSwapFeeFrom: 'targetToken',
           },
           {
             isDPMProxy: false,
@@ -1170,7 +1155,7 @@ describe(`Strategy | AAVE | Adjust Position`, async function () {
     let openTxStatus: boolean
     let txStatus: boolean
 
-    let feeRecipientWBTCBalanceBefore: BigNumber
+    let feeRecipientUSDCBalanceBefore: BigNumber
 
     let finalPosition: IPosition
     let positionTransition: IPositionTransition
@@ -1273,8 +1258,8 @@ describe(`Strategy | AAVE | Adjust Position`, async function () {
           },
         )
 
-        feeRecipientWBTCBalanceBefore = await balanceOf(
-          ADDRESSES.main.WBTC,
+        feeRecipientUSDCBalanceBefore = await balanceOf(
+          ADDRESSES.main.USDC,
           ADDRESSES.main.feeRecipient,
           { config },
         )
@@ -1351,13 +1336,13 @@ describe(`Strategy | AAVE | Adjust Position`, async function () {
     })
 
     it('Should collect fee', async () => {
-      const feeRecipientWBTCBalanceAfter = await balanceOf(
-        ADDRESSES.main.WBTC,
+      const feeRecipientUSDCBalanceAfter = await balanceOf(
+        ADDRESSES.main.USDC,
         ADDRESSES.main.feeRecipient,
         { config },
       )
 
-      const actualWBTCFees = feeRecipientWBTCBalanceAfter.minus(feeRecipientWBTCBalanceBefore)
+      const actualUSDCFees = feeRecipientUSDCBalanceAfter.minus(feeRecipientUSDCBalanceBefore)
 
       // Test for equivalence within slippage adjusted range when taking fee from target token
       expectToBe(
@@ -1367,7 +1352,7 @@ describe(`Strategy | AAVE | Adjust Position`, async function () {
             .toString(),
         ).toFixed(0),
         'gte',
-        actualWBTCFees,
+        actualUSDCFees,
       )
     })
   })

--- a/test/aave/DepositBorrow.test.ts
+++ b/test/aave/DepositBorrow.test.ts
@@ -1,5 +1,4 @@
 import { JsonRpcProvider } from '@ethersproject/providers'
-import { IPositionTransition } from '@oasisdex/oasis-actions'
 import { AAVETokens, ADDRESSES, ONE, Position, strategies, ZERO } from '@oasisdex/oasis-actions/src'
 import aavePriceOracleABI from '@oasisdex/oasis-actions/src/abi/aavePriceOracle.json'
 import { amountFromWei } from '@oasisdex/oasis-actions/src/helpers'
@@ -38,7 +37,7 @@ describe.only(`Strategy | AAVE | Deposit-Borrow`, async function () {
   describe('Uniswap t/x', function () {
     const slippage = new BigNumber(0.1)
 
-    let positionTransition: IPositionTransition
+    // let positionTransition: IPositionTransition
     let txStatus: boolean
     let gasEstimates: GasEstimateHelper
 
@@ -261,7 +260,7 @@ describe.only(`Strategy | AAVE | Deposit-Borrow`, async function () {
         )
 
         txStatus = setup.txStatus
-        positionTransition = setup.positionTransition
+        // positionTransition = setup.positionTransition
       })
 
       it('Tx should pass', function () {

--- a/test/aave/OpenDpm.test.ts
+++ b/test/aave/OpenDpm.test.ts
@@ -27,6 +27,7 @@ import { oneInchCallMock } from '../../helpers/swap/OneInchCallMock'
 import { swapUniswapTokens } from '../../helpers/swap/uniswap'
 import { RuntimeConfig } from '../../helpers/types/common'
 import { amountToWei, balanceOf } from '../../helpers/utils'
+import { acceptedFeeToken } from '../../packages/oasis-actions/src/helpers/acceptedFeeToken'
 import { mainnetAddresses } from '../addresses'
 import { testBlockNumber } from '../config'
 import { tokens } from '../constants'
@@ -71,7 +72,6 @@ describe(`Strategy | AAVE | Open Position with DPM wallet`, async function () {
       },
       positionType: PositionType,
       mockMarketPrice: BigNumber | undefined,
-      isFeeFromDebtToken: boolean,
       userAddress: Address,
       isDPMProxy: boolean,
     ) {
@@ -134,6 +134,11 @@ describe(`Strategy | AAVE | Open Position with DPM wallet`, async function () {
         operationExecutor: system.common.operationExecutor.address,
       }
 
+      const isFeeFromDebtToken =
+        acceptedFeeToken({
+          fromToken: debtToken.symbol,
+          toToken: collateralToken.symbol,
+        }) === 'sourceToken'
       const proxy = system.common.dpmProxyAddress
 
       const positionTransition = await strategies.aave.open(
@@ -271,7 +276,6 @@ describe(`Strategy | AAVE | Open Position with DPM wallet`, async function () {
           },
           'Earn',
           new BigNumber(0.9759),
-          true,
           userAddress,
           true,
         )

--- a/test/aave/ReopenStEth.test.ts
+++ b/test/aave/ReopenStEth.test.ts
@@ -19,6 +19,7 @@ import { deploySystem } from '../deploySystem'
 import { initialiseConfig } from '../fixtures'
 import { expectToBe, expectToBeEqual } from '../utils'
 
+// TODO: This tests are mostly failing. Either we fix them or remove.
 describe(`Strategy | AAVE | Reopen Position`, async () => {
   const depositAmountInWei = amountToWei(new BigNumber(1))
   const multiple = new BigNumber(2)
@@ -89,7 +90,6 @@ describe(`Strategy | AAVE | Reopen Position`, async () => {
           multiple,
           debtToken,
           collateralToken,
-          collectSwapFeeFrom: 'sourceToken',
           positionType: 'Earn',
         },
         {
@@ -148,13 +148,11 @@ describe(`Strategy | AAVE | Reopen Position`, async () => {
           debtToken,
           collateralToken,
           slippage,
-          collectSwapFeeFrom: 'targetToken',
         },
         {
           ...dependencies,
           isDPMProxy: false,
           currentPosition: beforeTransaction,
-          isDPMProxy: false,
           getSwapData: oneInchCallMock(mockMarketPriceOnClose, {
             from: collateralToken.precision,
             to: debtToken.precision,
@@ -213,7 +211,6 @@ describe(`Strategy | AAVE | Reopen Position`, async () => {
           multiple,
           debtToken,
           collateralToken,
-          collectSwapFeeFrom: 'sourceToken',
           positionType: 'Earn',
         },
         {
@@ -300,7 +297,6 @@ describe(`Strategy | AAVE | Reopen Position`, async () => {
           multiple,
           debtToken,
           collateralToken,
-          collectSwapFeeFrom: 'sourceToken',
           positionType: 'Earn',
         },
         {
@@ -359,7 +355,6 @@ describe(`Strategy | AAVE | Reopen Position`, async () => {
           slippage,
           debtToken,
           collateralToken,
-          collectSwapFeeFrom: 'targetToken',
         },
         {
           ...dependencies,
@@ -419,7 +414,6 @@ describe(`Strategy | AAVE | Reopen Position`, async () => {
           multiple,
           debtToken,
           collateralToken,
-          collectSwapFeeFrom: 'sourceToken',
           positionType: 'Earn',
         },
         {

--- a/test/fixtures/factories/createEthUsdcMultiplyAAVEPosition.ts
+++ b/test/fixtures/factories/createEthUsdcMultiplyAAVEPosition.ts
@@ -22,7 +22,6 @@ async function getEthUsdcMultiplyAAVEPosition(dependencies: OpenPositionTypes[1]
     },
     multiple: new BigNumber(1.5),
     positionType: 'Multiply',
-    collectSwapFeeFrom: 'sourceToken',
   }
 
   return await strategies.aave.open(args, dependencies)

--- a/test/fixtures/factories/createStEthEthEarnAAVEPosition.ts
+++ b/test/fixtures/factories/createStEthEthEarnAAVEPosition.ts
@@ -22,7 +22,6 @@ async function getStEthEthEarnAAVEPosition(dependencies: OpenPositionTypes[1]) {
     },
     multiple: new BigNumber(1.5),
     positionType: 'Earn',
-    collectSwapFeeFrom: 'sourceToken',
   }
 
   return await strategies.aave.open(args, dependencies)

--- a/test/fixtures/factories/createStEthUsdcMultiplyAAVEPosition.ts
+++ b/test/fixtures/factories/createStEthUsdcMultiplyAAVEPosition.ts
@@ -23,7 +23,6 @@ async function getStEthUsdcMultiplyAAVEPosition(dependencies: OpenPositionTypes[
     },
     multiple: new BigNumber(1.5),
     positionType: 'Multiply',
-    collectSwapFeeFrom: 'sourceToken',
   }
 
   return await strategies.aave.open(args, dependencies)

--- a/test/fixtures/factories/createWbtcUsdcMultiplyAAVEPosition.ts
+++ b/test/fixtures/factories/createWbtcUsdcMultiplyAAVEPosition.ts
@@ -23,7 +23,6 @@ async function getWbtcUsdcMultiplyAAVEPosition(dependencies: OpenPositionTypes[1
     },
     multiple: new BigNumber(1.5),
     positionType: 'Multiply',
-    collectSwapFeeFrom: 'sourceToken',
   }
 
   return await strategies.aave.open(args, dependencies)


### PR DESCRIPTION
https://app.shortcut.com/oazo-apps/story/7574/library-collecting-fee

* Strategies now self-determine what token they'll take the fee from for a swap
* All strategies in /strategies folder updated with args removed
* New acceptedFeeToken helper returns either sourceToken or targetToken when determining fee
* Tests updated accordingly