### PR TITLE
add maxDebtToBorrowWithCurrentCollateral to IPosition

### DIFF
--- a/packages/oasis-actions/package.json
+++ b/packages/oasis-actions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oasisdex/oasis-actions",
-  "version": "0.1.13-beta.2",
+  "version": "0.1.13-beta.3",
   "main": "lib/src/index.js",
   "typings": "lib/src/index.d.ts",
   "scripts": {

--- a/packages/oasis-actions/src/helpers/calculations/Position.ts
+++ b/packages/oasis-actions/src/helpers/calculations/Position.ts
@@ -104,6 +104,7 @@ export interface IPosition extends IBasePosition {
   relativeCollateralPriceMovementUntilLiquidation: BigNumber
   liquidationPrice: BigNumber
   maxDebtToBorrow: BigNumber
+  maxDebtToBorrowWithCurrentCollateral: BigNumber
   maxCollateralToWithdraw: BigNumber
   deposit(amount: BigNumber): IPosition
   borrow(amount: BigNumber): IPosition
@@ -152,6 +153,13 @@ export class Position implements IPosition {
       .times(this._oraclePriceForCollateralDebtExchangeRate)
       .times(maxLoanToValue)
       .minus(this.debt.normalisedAmount)
+  }
+
+  public get maxDebtToBorrowWithCurrentCollateral() {
+    const maxLoanToValue = this.category.maxLoanToValue
+    return this.collateral.normalisedAmount
+      .times(this._oraclePriceForCollateralDebtExchangeRate)
+      .times(maxLoanToValue)
   }
 
   public get maxCollateralToWithdraw() {

--- a/packages/oasis-actions/src/index.ts
+++ b/packages/oasis-actions/src/index.ts
@@ -9,5 +9,11 @@ export * from './helpers/constants'
 export * as operations from './operations'
 export { AAVEStrategyAddresses } from './operations/aave/addresses'
 export * as strategies from './strategies'
-export { IPositionTransition, SwapData } from './strategies/types'
+export {
+  IPositionTransition,
+  ISimplePositionTransition,
+  ISimpleSimulatedTransition,
+  ISimulatedTransition,
+  SwapData,
+} from './strategies/types'
 export { AavePosition, AAVETokens } from './strategies/types/aave'

--- a/packages/oasis-actions/src/strategies/types/IPositionTransition.ts
+++ b/packages/oasis-actions/src/strategies/types/IPositionTransition.ts
@@ -4,7 +4,7 @@ import { IRiskRatio } from '../../helpers/calculations/RiskRatio'
 import { OperationNames } from '../../helpers/constants'
 import { SwapData } from './SwapData'
 
-interface ISimulatedTransition extends IBaseSimulatedTransition {
+export interface ISimulatedTransition extends IBaseSimulatedTransition {
   swap: SwapData & Swap
   minConfigurableRiskRatio: IRiskRatio
 }


### PR DESCRIPTION
This PR is is a dependency for https://github.com/OasisDEX/oasis-borrow/pull/1948 and https://app.shortcut.com/oazo-apps/story/7641/open-aave-borrow-base-form

- Adds a new method `maxDebtToBorrowWithCurrentCollateral` to Position and IPosition.
- Exposes IPositionTransition, ISimplePositionTransition, ISimpleSimulatedTransition, ISimulatedTransition outside, so we can easily detect the different types.
- Publishes new version