### PR TITLE
Ajna borrow max ltv offset validations

### DIFF
--- a/packages/oasis-actions/package.json
+++ b/packages/oasis-actions/package.json
@@ -2,7 +2,7 @@
   "name": "@oasisdex/oasis-actions",
   "main": "lib/packages/oasis-actions/src/index.js",
   "typings": "lib/packages/oasis-actions/src/index.d.ts",
-  "version": "0.2.16-ajna-earn-30",
+  "version": "0.2.16-ajna-earn-31",
   "scripts": {
     "build": "tsc -b",  
     "watch": "tsc -b -w",

--- a/packages/oasis-actions/src/strategies/ajna/depositBorrow.ts
+++ b/packages/oasis-actions/src/strategies/ajna/depositBorrow.ts
@@ -10,6 +10,7 @@ import {
   validateDustLimit,
   validateLiquidity,
 } from './validation'
+import { validateGenerateCloseToMaxLtv } from './validation/closeToMaxLtv'
 
 export interface DepositBorrowArgs extends Omit<OpenArgs, 'collateralPrice' | 'quotePrice'> {
   position: AjnaPosition
@@ -47,11 +48,13 @@ export async function depositBorrow(
     ...validateLiquidity(targetPosition, args.quoteAmount),
   ]
 
+  const warnings = [...validateGenerateCloseToMaxLtv(targetPosition, args.position)]
+
   return prepareAjnaPayload({
     dependencies,
     targetPosition,
     errors,
-    warnings: [],
+    warnings,
     data,
     txValue: resolveAjnaEthAction(isDepositingEth, args.collateralAmount),
   })

--- a/packages/oasis-actions/src/strategies/ajna/paybackWithdraw.ts
+++ b/packages/oasis-actions/src/strategies/ajna/paybackWithdraw.ts
@@ -12,6 +12,7 @@ import {
   validateOverWithdraw,
   validateWithdrawUndercollateralized,
 } from './validation'
+import { validateWithdrawCloseToMaxLtv } from './validation/closeToMaxLtv'
 
 interface PaybackWithdrawArgs {
   poolAddress: Address
@@ -53,11 +54,13 @@ export async function paybackWithdraw(
     // ...validateOverRepay(args.position, args.quoteAmount),
   ]
 
+  const warnings = [...validateWithdrawCloseToMaxLtv(targetPosition, args.position)]
+
   return prepareAjnaPayload({
     dependencies,
     targetPosition,
     errors,
-    warnings: [],
+    warnings,
     data,
     txValue: resolveAjnaEthAction(isPayingBackEth, args.quoteAmount),
   })

--- a/packages/oasis-actions/src/strategies/ajna/validation/closeToMaxLtv.ts
+++ b/packages/oasis-actions/src/strategies/ajna/validation/closeToMaxLtv.ts
@@ -1,0 +1,42 @@
+import { AjnaPosition } from '../../../types/ajna'
+import { AjnaWarning } from '../../../types/common'
+
+const MAX_LTV_OFFSET = 0.05
+
+export function validateGenerateCloseToMaxLtv(
+  position: AjnaPosition,
+  positionBefore: AjnaPosition,
+): AjnaWarning[] {
+  if (position.maxRiskRatio.loanToValue.minus(MAX_LTV_OFFSET).lte(position.riskRatio.loanToValue)) {
+    return [
+      {
+        name: 'generate-close-to-max-ltv',
+        data: {
+          amount: position.debtAmount.minus(positionBefore.debtAmount).decimalPlaces(2).toString(),
+        },
+      },
+    ]
+  }
+  return []
+}
+
+export function validateWithdrawCloseToMaxLtv(
+  position: AjnaPosition,
+  positionBefore: AjnaPosition,
+): AjnaWarning[] {
+  if (position.maxRiskRatio.loanToValue.minus(MAX_LTV_OFFSET).lte(position.riskRatio.loanToValue)) {
+    return [
+      {
+        name: 'withdraw-close-to-max-ltv',
+        data: {
+          amount: position.collateralAmount
+            .minus(positionBefore.collateralAmount)
+            .decimalPlaces(5)
+            .abs()
+            .toString(),
+        },
+      },
+    ]
+  }
+  return []
+}

--- a/packages/oasis-actions/src/types/common/index.ts
+++ b/packages/oasis-actions/src/types/common/index.ts
@@ -80,7 +80,24 @@ export type AjnaWarningPriceBelowHtp = {
   name: 'price-below-htp'
 }
 
-export type AjnaWarning = AjnaWarningPriceBelowHtp
+type AjnaWarningGenerateCloseToMaxLtv = {
+  name: 'generate-close-to-max-ltv'
+  data: {
+    amount: string
+  }
+}
+
+type AjnaWarningWithdrawCloseToMaxLtv = {
+  name: 'withdraw-close-to-max-ltv'
+  data: {
+    amount: string
+  }
+}
+
+export type AjnaWarning =
+  | AjnaWarningPriceBelowHtp
+  | AjnaWarningGenerateCloseToMaxLtv
+  | AjnaWarningWithdrawCloseToMaxLtv
 
 export type Strategy<Position> = {
   simulation: {


### PR DESCRIPTION
# Ajna borrow max ltv offset validations

https://app.shortcut.com/oazo-apps/story/8294/ajna-warning-handling-generate-debt-resulting-in-ltv-within-5-of-maximum-ltv

https://app.shortcut.com/oazo-apps/story/8295/ajna-warning-handling-withdraw-collateral-resulting-in-ltv-within-5-of-max-ltv

- added validation for case where user is withdrawing collateral and this action would result in after ltv to be within range of 5% to max ltv
- added validation for case where user is generating debt and this action would result in after ltv to be within range of 5% to max ltv

Testing is self explanatory

