### PR TITLE
Add Ci tests workflow

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - name: Check out github repository
         id: github-checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 2
 
@@ -40,7 +40,7 @@ jobs:
 
       - name: Install node
         id: install-node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         if: contains(steps.changed-files.outputs.all_changed_and_modified_files, matrix.package)
         with:
           node-version: "16.x"
@@ -70,7 +70,7 @@ jobs:
     steps:
       - name: Check out github repository
         id: github-checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 2
 
@@ -88,7 +88,7 @@ jobs:
 
       - name: Install node
         id: install-node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         if: contains(steps.changed-files.outputs.all_changed_and_modified_files, matrix.package)
         with:
           node-version: "16.x"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,110 @@
+name: Tests
+
+on:
+  push:
+    branches:
+      - dev
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      force_run_tests:
+        description: 'Force run tests (true/false)'
+        required: false
+        default: 'false'
+
+jobs:
+  unit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      matrix:
+        package: ["dma-contracts", "domain"]
+    steps:
+      - name: Check out github repository
+        id: github-checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
+
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v11
+
+      - name: Cache node modules
+        id: cache-node-modules
+        uses: actions/cache@v2
+        if: contains(steps.changed-files.outputs.all_changed_and_modified_files, matrix.package)
+        with:
+          path: "**/node_modules"
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+
+      - name: Install node
+        id: install-node
+        uses: actions/setup-node@v1
+        if: contains(steps.changed-files.outputs.all_changed_and_modified_files, matrix.package)
+        with:
+          node-version: "12.x"
+
+      # Modify the `if` condition to check for changes in either `dma-contracts` or `dma-library` for the `dma-contracts` matrix entry
+      - name: Install dependencies & build packages & compile contracts
+        id: install-dependencies
+        if: (github.event.inputs.force_run_tests == 'true') || (matrix.package == 'dma-contracts' && (contains(steps.changed-files.outputs.all_changed_and_modified_files, 'dma-contracts') || contains(steps.changed-files.outputs.all_changed_and_modified_files, 'dma-library'))) || (matrix.package == 'domain' && contains(steps.changed-files.outputs.all_changed_and_modified_files, matrix.package))
+        run: yarn ; yarn build ; yarn compile
+        env:
+          BLOCK_NUMBER: 15946543
+          NETWORK_FORK: 'mainnet'
+          MAINNET_URL: ${{ secrets.MAINNET_URL }}
+
+      # Modify the `if` condition to check for changes in either `dma-contracts` or `dma-library` for the `dma-contracts` matrix entry
+      - name: Run unit tests
+        id: unit-test
+        if: (github.event.inputs.force_run_tests == 'true') || (matrix.package == 'dma-contracts' && (contains(steps.changed-files.outputs.all_changed_and_modified_files, 'dma-contracts') || contains(steps.changed-files.outputs.all_changed_and_modified_files, 'dma-library'))) || (matrix.package == 'domain' && contains(steps.changed-files.outputs.all_changed_and_modified_files, matrix.package))
+        run: lerna exec --scope @oasisdex/${{ matrix.package }} -- yarn test:unit
+
+  e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      matrix:
+        package: ["dma-contracts", "domain"]
+    steps:
+      - name: Check out github repository
+        id: github-checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
+
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v11
+
+      - name: Cache node modules
+        id: cache-node-modules
+        uses: actions/cache@v2
+        if: contains(steps.changed-files.outputs.all_changed_and_modified_files, matrix.package)
+        with:
+          path: "**/node_modules"
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+
+      - name: Install node
+        id: install-node
+        uses: actions/setup-node@v1
+        if: contains(steps.changed-files.outputs.all_changed_and_modified_files, matrix.package)
+        with:
+          node-version: "12.x"
+
+      # Modify the `if` condition to check for changes in either `dma-contracts` or `dma-library` for the `dma-contracts` matrix entry
+      - name: Install dependencies & build packages & compile contracts
+        id: install-dependencies
+        if: (github.event.inputs.force_run_tests == 'true') || (matrix.package == 'dma-contracts' && (contains(steps.changed-files.outputs.all_changed_and_modified_files, 'dma-contracts') || contains(steps.changed-files.outputs.all_changed_and_modified_files, 'dma-library'))) || (matrix.package == 'domain' && contains(steps.changed-files.outputs.all_changed_and_modified_files, matrix.package))
+        run: yarn ; yarn build ; yarn compile
+        env:
+          BLOCK_NUMBER: 15946543
+          NETWORK_FORK: 'mainnet'
+          MAINNET_URL: ${{ secrets.MAINNET_URL }}
+
+      - name: Run e2e tests
+        id: e2e-test
+        #        if: contains(steps.changed-files.outputs.all_changed_and_modified_files, matrix.package)
+        if: (github.event.inputs.force_run_tests == 'true') || (matrix.package == 'dma-contracts' && (contains(steps.changed-files.outputs.all_changed_and_modified_files, 'dma-contracts') || contains(steps.changed-files.outputs.all_changed_and_modified_files, 'dma-library'))) || (matrix.package == 'domain' && contains(steps.changed-files.outputs.all_changed_and_modified_files, matrix.package))
+        run: lerna exec --scope @oasisdex/${{ matrix.package }} -- yarn test:e2e

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -43,7 +43,7 @@ jobs:
         uses: actions/setup-node@v1
         if: contains(steps.changed-files.outputs.all_changed_and_modified_files, matrix.package)
         with:
-          node-version: "12.x"
+          node-version: "16.x"
 
       # Modify the `if` condition to check for changes in either `dma-contracts` or `dma-library` for the `dma-contracts` matrix entry
       - name: Install dependencies & build packages & compile contracts
@@ -91,7 +91,7 @@ jobs:
         uses: actions/setup-node@v1
         if: contains(steps.changed-files.outputs.all_changed_and_modified_files, matrix.package)
         with:
-          node-version: "12.x"
+          node-version: "16.x"
 
       # Modify the `if` condition to check for changes in either `dma-contracts` or `dma-library` for the `dma-contracts` matrix entry
       - name: Install dependencies & build packages & compile contracts

--- a/TODO.md
+++ b/TODO.md
@@ -2,7 +2,6 @@
 - Add Lerna Changelog https://github.com/lerna/lerna-changelog
 - Add Husky to perform checks before commit
 - Update the many skipped tests
-- Setup Unit & E2E tests workflows
 - Add instructions for regenerating domain unit tests scenarios
 - Update name of index() function
 - Ensure docs are in sync with GitBook (determine if still relevant)


### PR DESCRIPTION
See https://app.shortcut.com/oazo-apps/story/8852/add-tests-workflow-to-ci

**Description**
Ci based tests workflow. Checks for diffs in packages to decide when to run tests. Library changes trigger tests in dma-contracts package.

**Changes**
- Add unit & e2e tests workflow to repo
- Manual tests trigger in place