### PR TITLE
chore - change node version to `18.12.1`

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -8,6 +8,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18.12.1
+          
       - name: Cache Yarn dependencies
         uses: actions/cache@v3
         with:


### PR DESCRIPTION
- add gh action to change node version to `18.12.1`
```yaml

      - uses: actions/setup-node@v3
        with:
          node-version: 18.12.1
```
-  specific version has been recommended in gh issue regarding hardhat's solidity compiler download issue https://github.com/NomicFoundation/hardhat/issues/3877#issuecomment-1521613467