### PR TITLE
price above momp is warning, not error

### DIFF
--- a/packages/dma-library/package.json
+++ b/packages/dma-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oasisdex/dma-library",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "typings": "lib/index.d.ts",
   "types": "lib/index.d.ts",
   "main": "lib/index.js",

--- a/packages/dma-library/src/strategies/ajna/earn/validations.ts
+++ b/packages/dma-library/src/strategies/ajna/earn/validations.ts
@@ -25,7 +25,7 @@ export const getAjnaEarnValidations = ({
 
   // common
   if (price.gt(position.pool.mostOptimisticMatchingPrice)) {
-    errors.push({
+    warnings.push({
       name: 'price-above-momp',
     })
   }

--- a/packages/dma-library/src/types/common/index.ts
+++ b/packages/dma-library/src/types/common/index.ts
@@ -22,10 +22,6 @@ export type AjnaErrorDustLimit = {
   }
 }
 
-export type AjnaErrorPriceAboveMomp = {
-  name: 'price-above-momp'
-}
-
 export type AjnaErrorWithdrawMoreThanAvailable = {
   name: 'withdraw-more-than-available'
   data: {
@@ -61,7 +57,6 @@ export type AjnaErrorOverRepay = {
 export type AjnaError =
   | AjnaErrorWithdrawUndercollateralized
   | AjnaErrorBorrowUndercollateralized
-  | AjnaErrorPriceAboveMomp
   | AjnaErrorWithdrawMoreThanAvailable
   | AjnaErrorAfterLupIndexBiggerThanHtpIndex
   | AjnaErrorDustLimit
@@ -71,6 +66,10 @@ export type AjnaError =
 
 export type AjnaWarningPriceBelowHtp = {
   name: 'price-below-htp'
+}
+
+export type AjnaWarningPriceAboveMomp = {
+  name: 'price-above-momp'
 }
 
 type AjnaWarningGenerateCloseToMaxLtv = {
@@ -91,6 +90,7 @@ export type AjnaWarning =
   | AjnaWarningPriceBelowHtp
   | AjnaWarningGenerateCloseToMaxLtv
   | AjnaWarningWithdrawCloseToMaxLtv
+  | AjnaWarningPriceAboveMomp
 
 export type Strategy<Position> = {
   simulation: {


### PR DESCRIPTION
Changes:

- Marked `price-above-momp` as warning, not as error.