### PR TITLE
Update DAI address for goerli

### DIFF
--- a/packages/addresses/package.json
+++ b/packages/addresses/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oasisdex/addresses",
-  "version": "0.0.21",
+  "version": "0.0.22",
   "typings": "lib/index.d.ts",
   "types": "lib/index.d.ts",
   "main": "lib/index.js",

--- a/packages/deploy-configurations/configs/goerli.conf.ts
+++ b/packages/deploy-configurations/configs/goerli.conf.ts
@@ -348,7 +348,7 @@ export const config: SystemConfig = {
     CRVV1ETHSTETH: { name: 'CRVV1ETHSTETH', address: ADDRESS_ZERO },
     DAI: {
       name: 'DAI',
-      address: '0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1',
+      address: '0x11fE4B6AE13d2a6055C8D9cF65c55bac32B5d844',
       serviceRegistryName: 'DAI',
     },
     ETH: { name: 'ETH', address: '0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6' },


### PR DESCRIPTION
`0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1` is a DAI optimism address that was incorrectly pasted in to goerli config. Switched it to `0x11fE4B6AE13d2a6055C8D9cF65c55bac32B5d844` which is used in Maker.