### PR TITLE
feat: allow opting in and out staking for earn positions

### DIFF
--- a/packages/ajna-contracts/contracts/ajna/ajna-actions/AjnaProxyActions.sol
+++ b/packages/ajna-contracts/contracts/ajna/ajna-actions/AjnaProxyActions.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.18;
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { ERC721 } from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 
-import { IPoolInfoUtils } from "../../interfaces/IPoolInfoUtils.sol";
+import { IAjnaPoolUtilsInfo } from "../../interfaces/ajna/IAjnaPoolUtilsInfo.sol";
 import { IERC20Pool } from "../interfaces/pool/erc20/IERC20Pool.sol";
 import { IPositionManager } from "../interfaces/position/IPositionManager.sol";
 import { IRewardsManager } from "../interfaces/rewards/IRewardsManager.sol";
@@ -22,7 +22,7 @@ interface IAjnaProxyActions {
 }
 
 contract AjnaProxyActions is IAjnaProxyActions {
-    IPoolInfoUtils public immutable poolInfoUtils;
+    IAjnaPoolUtilsInfo public immutable poolInfoUtils;
     IERC20 public immutable ajnaToken;
     address public immutable WETH;
     address public immutable GUARD;
@@ -31,7 +31,7 @@ contract AjnaProxyActions is IAjnaProxyActions {
     IRewardsManager public rewardsManager;
     address public ARC;
 
-    constructor(IPoolInfoUtils _poolInfoUtils, IERC20 _ajnaToken, address _WETH, address _GUARD) {
+    constructor(IAjnaPoolUtilsInfo _poolInfoUtils, IERC20 _ajnaToken, address _WETH, address _GUARD) {
         poolInfoUtils = _poolInfoUtils;
         ajnaToken = _ajnaToken;
         WETH = _WETH;

--- a/packages/ajna-contracts/contracts/ajna/ajna-actions/AjnaProxyActions.sol
+++ b/packages/ajna-contracts/contracts/ajna/ajna-actions/AjnaProxyActions.sol
@@ -26,6 +26,7 @@ contract AjnaProxyActions is IAjnaProxyActions {
     IERC20 public immutable ajnaToken;
     address public immutable WETH;
     address public immutable GUARD;
+    address public immutable deployer;
     IAjnaProxyActions public immutable self;
     IPositionManager public positionManager;
     IRewardsManager public rewardsManager;
@@ -37,9 +38,11 @@ contract AjnaProxyActions is IAjnaProxyActions {
         WETH = _WETH;
         GUARD = _GUARD;
         self = this;
+        deployer = msg.sender;
     }
 
     function initialize(address _positionManager, address _rewardsManager, address _ARC) external {
+        require(msg.sender == deployer, "apa/not-deployer");
         require(
             address(positionManager) == address(0) && address(rewardsManager) == address(0) && ARC == address(0),
             "apa/already-initialized"

--- a/packages/ajna-contracts/contracts/ajna/ajna-actions/AjnaProxyActions.sol
+++ b/packages/ajna-contracts/contracts/ajna/ajna-actions/AjnaProxyActions.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.18;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import { ERC721 } from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+import { IERC721 } from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 
 import { IAjnaPoolUtilsInfo } from "../../interfaces/ajna/IAjnaPoolUtilsInfo.sol";
 import { IERC20Pool } from "../interfaces/pool/erc20/IERC20Pool.sol";
@@ -136,7 +136,7 @@ contract AjnaProxyActions is IAjnaProxyActions {
         lpCounts[0] = lpCount;
         IERC20Pool(pool).increaseLPAllowance(address(self.positionManager()), indexes, lpCounts);
         self.positionManager().memorializePositions(address(pool), tokenId, indexes);
-        ERC721(address(self.positionManager())).approve(address(self.rewardsManager()), tokenId);
+        IERC721(address(self.positionManager())).approve(address(self.rewardsManager()), tokenId);
     }
 
     /**
@@ -151,7 +151,7 @@ contract AjnaProxyActions is IAjnaProxyActions {
         uint256 newIndex = convertPriceToIndex(newPrice);
 
         self.positionManager().moveLiquidity(pool, tokenId, oldIndex, newIndex, block.timestamp + 1);
-        ERC721(address(self.positionManager())).approve(address(self.rewardsManager()), tokenId);
+        IERC721(address(self.positionManager())).approve(address(self.rewardsManager()), tokenId);
     }
 
     /**

--- a/packages/ajna-contracts/contracts/ajna/ajna-actions/AjnaRewardClaimer.sol
+++ b/packages/ajna-contracts/contracts/ajna/ajna-actions/AjnaRewardClaimer.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.18;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
-import { RewardsManager } from "../RewardsManager.sol";
+import { IRewardsManager } from "../interfaces/rewards/IRewardsManager.sol";
 import { IAccountImplementation } from "../../interfaces/dpm/IAccountImplementation.sol";
 import { IAccountGuard } from "../../interfaces/dpm/IAccountGuard.sol";
 import { IServiceRegistry } from "../../interfaces/IServiceRegistry.sol";
@@ -18,7 +18,7 @@ error OnlyNotDelegate();
 error ApaNotWhitelisted(address);
 
 contract AjnaRewardClaimer {
-    RewardsManager public immutable rewardsManager;
+    IRewardsManager public immutable rewardsManager;
     IAccountGuard public immutable guard;
     IERC20 public immutable ajnaToken;
     address public immutable self;
@@ -33,7 +33,7 @@ contract AjnaRewardClaimer {
 
     event AjnaRewardClaimed(address indexed proxy, address indexed pool, uint256 indexed tokenId);
 
-    constructor(RewardsManager _rewardsManager, IERC20 _ajnaToken, IServiceRegistry _serviceRegistry) {
+    constructor(IRewardsManager _rewardsManager, IERC20 _ajnaToken, IServiceRegistry _serviceRegistry) {
         rewardsManager = _rewardsManager;
         ajnaToken = _ajnaToken;
         self = address(this);

--- a/packages/ajna-contracts/contracts/interfaces/IPoolInfoUtils.sol
+++ b/packages/ajna-contracts/contracts/interfaces/IPoolInfoUtils.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.15;
+
+interface IPoolInfoUtils {
+    function priceToIndex(uint256 price_) external pure returns (uint256);
+
+    function borrowerInfo(
+        address pool_,
+        address borrower_
+    ) external view returns (uint256 debt_, uint256 collateral_, uint256 index_);
+
+    function poolPricesInfo(
+        address ajnaPool_
+    )
+        external
+        view
+        returns (uint256 hpb_, uint256 hpbIndex_, uint256 htp_, uint256 htpIndex_, uint256 lup_, uint256 lupIndex_);
+
+    function lpToQuoteTokens(
+        address ajnaPool_,
+        uint256 lp_,
+        uint256 index_
+    ) external view returns (uint256 quoteAmount_);
+}

--- a/packages/ajna-contracts/contracts/interfaces/ajna/IAjnaPoolUtilsInfo.sol
+++ b/packages/ajna-contracts/contracts/interfaces/ajna/IAjnaPoolUtilsInfo.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.15;
 
-interface IPoolInfoUtils {
+interface IAjnaPoolUtilsInfo {
     function priceToIndex(uint256 price_) external pure returns (uint256);
 
     function borrowerInfo(

--- a/packages/ajna-contracts/scripts/common/deployment.utils.ts
+++ b/packages/ajna-contracts/scripts/common/deployment.utils.ts
@@ -97,7 +97,8 @@ export async function deployApa(
   dmpGuardContract: Contract,
   guardDeployerSigner: Signer,
   weth: WETH,
-  ajna: Token
+  ajna: Token,
+  initializeStaking = true
 ) {
   const { serviceRegistryContract } = await deployServiceRegistry();
   const hash = await serviceRegistryContract.getServiceNameHash("DPM_GUARD");
@@ -120,8 +121,11 @@ export async function deployApa(
     weth.address,
     dmpGuardContract.address,
   ]);
-  await ajnaProxyActionsContract.initialize(positionManager.address, rewardsManager.address, arc.address);
-  await arc.initializeAjnaProxyActions(ajnaProxyActionsContract.address);
+
+  if (initializeStaking) {
+    await ajnaProxyActionsContract.initialize(positionManager.address, rewardsManager.address, arc.address);
+    await arc.initializeAjnaProxyActions(ajnaProxyActionsContract.address);
+  }
 
   await dmpGuardContract.connect(guardDeployerSigner).setWhitelist(ajnaProxyActionsContract.address, true);
 

--- a/packages/ajna-contracts/scripts/common/deployment.utils.ts
+++ b/packages/ajna-contracts/scripts/common/deployment.utils.ts
@@ -116,14 +116,11 @@ export async function deployApa(
 
   const ajnaProxyActionsContract = await utils.deployContract<AjnaProxyActions>("AjnaProxyActions", [
     poolInfoContract.address,
-    positionManager.address,
-    rewardsManager.address,
     ajna.address,
     weth.address,
-    arc.address,
     dmpGuardContract.address,
   ]);
-
+  await ajnaProxyActionsContract.initialize(positionManager.address, rewardsManager.address, arc.address);
   await arc.initializeAjnaProxyActions(ajnaProxyActionsContract.address);
 
   await dmpGuardContract.connect(guardDeployerSigner).setWhitelist(ajnaProxyActionsContract.address, true);

--- a/packages/ajna-contracts/scripts/deploy-apa.ts
+++ b/packages/ajna-contracts/scripts/deploy-apa.ts
@@ -1,9 +1,10 @@
 import { ethers } from "hardhat";
 
 async function main() {
-  const POOL_INFO_UTILS = "0x1F9F7732ff409FC0AbcAAea94634A7b41F445299";
-  const POSITION_MANAGER = "0x83AB3762A4AeC9FBD4e7c01581C9495f2160630b";
-  const REWARD_MANAGER = "0xaF9bc1F09fe561CbD00018fC352507fD23cD46E2";
+  // RC5 addresses
+  const POOL_INFO_UTILS = "0x28ef92e694d1044917981837b21e5eA994931c71";
+  const POSITION_MANAGER = "0x31E3B448cAFF35e9eEb232053f4d5e76776a1C83";
+  const REWARD_MANAGER = "0x015441062c2aad707629D9A1f2029074F58ad5aE";
   const AJNA_TOKEN = "0xaadebCF61AA7Da0573b524DE57c67aDa797D46c5";
   const WETH = "0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6";
   const GUARD = "0x9319710C25cdaDDD1766F0bDE40F1A4034C17c7e";
@@ -15,16 +16,9 @@ async function main() {
 
   const AjnaProxyActions = await ethers.getContractFactory("AjnaProxyActions");
   // hardcoded addresses for now
-  const apa = await AjnaProxyActions.deploy(
-    POOL_INFO_UTILS,
-    POSITION_MANAGER,
-    REWARD_MANAGER,
-    AJNA_TOKEN,
-    WETH,
-    ARC,
-    GUARD
-  );
+  const apa = await AjnaProxyActions.deploy(POOL_INFO_UTILS, AJNA_TOKEN, WETH, GUARD);
   await apa.deployed();
+  await apa.initialize(POSITION_MANAGER, REWARD_MANAGER, ARC);
   console.log(`AjnaRewardsClaimer Deployed: ${arc.address}`);
   console.log(`AjnaProxyActions Deployed: ${apa.address}`);
 }

--- a/packages/ajna-contracts/test/pool.dpm.test.ts
+++ b/packages/ajna-contracts/test/pool.dpm.test.ts
@@ -1080,6 +1080,7 @@ describe.only("AjnaProxyActions", function () {
       const depositedQuoteAmount = await poolInfoContract.lpToQuoteTokens(poolContract.address, lpBalance_, index);
       expect(depositedQuoteAmount).to.be.equal(bn.eighteen.THOUSAND);
       expect(balancesQuoteAfter.lender).to.be.equal(balancesQuoteBefore.lender.sub(bn.six.THOUSAND));
+      expect(await ajnaProxyActionsContract.positionManager()).to.be.equal(ethers.constants.AddressZero);
     });
     it("should supplyQuote --> moveQuote", async () => {
       const { lenderProxy, poolContract, ajnaProxyActionsContract, lender, usdc, poolInfoContract } = await loadFixture(
@@ -1131,6 +1132,7 @@ describe.only("AjnaProxyActions", function () {
       );
       expect(newDepositedQuoteAmount).to.be.equal(bn.eighteen.HUNDRED_THOUSAND);
       expect(balancesQuoteAfter.lender).to.be.equal(balancesQuoteBefore.lender.sub(bn.six.HUNDRED_THOUSAND));
+      expect(await ajnaProxyActionsContract.positionManager()).to.be.equal(ethers.constants.AddressZero);
     });
     it("should supplyAndMoveQuote", async () => {
       const { lenderProxy, poolContract, ajnaProxyActionsContract, lender, usdc, poolInfoContract } = await loadFixture(
@@ -1183,6 +1185,7 @@ describe.only("AjnaProxyActions", function () {
       );
       expect(newDepositedQuoteAmount).to.be.equal(bn.eighteen.HUNDRED_THOUSAND.mul(2));
       expect(balancesQuoteAfter.lender).to.be.equal(balancesQuoteBefore.lender.sub(bn.six.HUNDRED_THOUSAND.mul(2)));
+      expect(await ajnaProxyActionsContract.positionManager()).to.be.equal(ethers.constants.AddressZero);
     });
     it("should withdrawAndMoveQuote", async () => {
       const { lenderProxy, poolContract, ajnaProxyActionsContract, lender, usdc, poolInfoContract } = await loadFixture(
@@ -1230,6 +1233,7 @@ describe.only("AjnaProxyActions", function () {
       );
       expect(newDepositedQuoteAmount).to.be.equal(bn.eighteen.TEN_THOUSAND.mul(9));
       expect(balancesQuoteAfter.lender).to.be.equal(balancesQuoteBefore.lender.sub(lendAmount).add(withdrawAmount));
+      expect(await ajnaProxyActionsContract.positionManager()).to.be.equal(ethers.constants.AddressZero);
     });
     it("should supplyQuote and withdrawQuote", async () => {
       const { lenderProxy, poolContract, ajnaProxyActionsContract, lender, usdc } = await loadFixture(
@@ -1254,6 +1258,7 @@ describe.only("AjnaProxyActions", function () {
       };
       // there are no borrowers hence the depoisit is not earning
       expect(balancesQuoteAfter.lender).to.be.equal(balancesQuoteBefore.lender);
+      expect(await ajnaProxyActionsContract.positionManager()).to.be.equal(ethers.constants.AddressZero);
     });
     it("should supplyQuote and withdrawQuote and accrue interest", async () => {
       const { wbtc, lenderProxy, poolContract, ajnaProxyActionsContract, lender, usdc, borrower, borrowerProxy } =
@@ -1297,6 +1302,7 @@ describe.only("AjnaProxyActions", function () {
       };
       // expected that the lender will get more quote tokens due to interest
       expect(balancesQuoteAfter.lender).to.be.gt(balancesQuoteBefore.lender);
+      expect(await ajnaProxyActionsContract.positionManager()).to.be.equal(ethers.constants.AddressZero);
     });
   });
 });

--- a/packages/dma-contracts/contracts/interfaces/ajna/IAjnaPoolUtilsInfo.sol
+++ b/packages/dma-contracts/contracts/interfaces/ajna/IAjnaPoolUtilsInfo.sol
@@ -8,4 +8,24 @@ interface IAjnaPoolUtilsInfo {
     address pool_,
     address borrower_
   ) external view returns (uint256 debt_, uint256 collateral_, uint256 index_);
+
+  function poolPricesInfo(
+    address ajnaPool_
+  )
+    external
+    view
+    returns (
+      uint256 hpb_,
+      uint256 hpbIndex_,
+      uint256 htp_,
+      uint256 htpIndex_,
+      uint256 lup_,
+      uint256 lupIndex_
+    );
+
+  function lpToQuoteTokens(
+    address ajnaPool_,
+    uint256 lp_,
+    uint256 index_
+  ) external view returns (uint256 quoteAmount_);
 }


### PR DESCRIPTION
- add  `optInStaking` emitting `AjnaOptInStaking`
- add `optOutStaking` emitting `AjnaOptOutStaking`
- remove `positionManager`, `rewardsManager`, `ARC` from AjnaProxyActions constructor
- add a function to initialize  `positionManager`, `rewardsManager`, `ARC` after they are deployed
- change all references to  `positionManager`, `rewardsManager`, `ARC` to external calls to the proxy contract to read from ProxyActions storage