### PR TITLE
Remove isEarningFees from apy calculation

### DIFF
--- a/packages/dma-library/package.json
+++ b/packages/dma-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oasisdex/dma-library",
-  "version": "0.3.33",
+  "version": "0.3.34",
   "typings": "lib/index.d.ts",
   "types": "lib/index.d.ts",
   "main": "lib/index.js",

--- a/packages/dma-library/src/types/ajna/ajna-earn-position.ts
+++ b/packages/dma-library/src/types/ajna/ajna-earn-position.ts
@@ -79,16 +79,6 @@ export class AjnaEarnPosition implements IAjnaEarn {
   }
 
   get apy() {
-    if (!this.isEarningFees) {
-      return {
-        per1d: ZERO,
-        per7d: ZERO,
-        per30d: ZERO,
-        per90d: ZERO,
-        per365d: ZERO,
-      }
-    }
-
     return {
       per1d: this.getApyPerDays({ amount: this.quoteTokenAmount, days: 1 }),
       per7d: this.getApyPerDays({ amount: this.quoteTokenAmount, days: 7 }),


### PR DESCRIPTION
# [Remove isEarningFees from apy calculation](https://app.shortcut.com/oazo-apps/story/10280/earn-deposit-fee-is-not-showing-below-htp)

- removed `isEarnigFees` check from apy calculations so it will be resolved on frontend