### PR TITLE
Update total earnings and pnl calculations for Ajna Earn

### DIFF
--- a/packages/dma-library/package.json
+++ b/packages/dma-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oasisdex/dma-library",
-  "version": "0.3.34",
+  "version": "0.3.35",
   "typings": "lib/index.d.ts",
   "types": "lib/index.d.ts",
   "main": "lib/index.js",

--- a/packages/dma-library/src/views/ajna/index.ts
+++ b/packages/dma-library/src/views/ajna/index.ts
@@ -117,11 +117,6 @@ export async function getEarnPosition(
     .minus(cumulativeDeposit.minus(cumulativeWithdraw).plus(cumulativeFees))
     .div(quotePrice)
 
-  console.log(`netValue: ${netValue}`)
-  console.log(`cumulativeDeposit: ${cumulativeDeposit}`)
-  console.log(`cumulativeWithdraw: ${cumulativeWithdraw}`)
-  console.log(`cumulativeFees: ${cumulativeFees}`)
-
   return new AjnaEarnPosition(
     pool,
     proxyAddress,

--- a/packages/dma-library/src/views/ajna/index.ts
+++ b/packages/dma-library/src/views/ajna/index.ts
@@ -109,13 +109,18 @@ export async function getEarnPosition(
 
   const netValue = quoteTokenAmount.times(quotePrice)
   const pnl = cumulativeWithdraw
-    .plus(quoteTokenAmount)
+    .plus(netValue)
     .minus(cumulativeFees)
     .minus(cumulativeDeposit)
     .div(cumulativeDeposit)
-  const totalEarnings = quoteTokenAmount.minus(
-    cumulativeDeposit.minus(cumulativeWithdraw).plus(cumulativeFees),
-  )
+  const totalEarnings = netValue
+    .minus(cumulativeDeposit.minus(cumulativeWithdraw).plus(cumulativeFees))
+    .div(quotePrice)
+
+  console.log(`netValue: ${netValue}`)
+  console.log(`cumulativeDeposit: ${cumulativeDeposit}`)
+  console.log(`cumulativeWithdraw: ${cumulativeWithdraw}`)
+  console.log(`cumulativeFees: ${cumulativeFees}`)
 
   return new AjnaEarnPosition(
     pool,


### PR DESCRIPTION
Cumulative values from subgraph are returned in USD, so they had to be recalculated into quote token price.