### PR TITLE
Bring back max generate calculations and validations

### DIFF
--- a/packages/dma-library/package.json
+++ b/packages/dma-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oasisdex/dma-library",
-  "version": "0.3.39",
+  "version": "0.3.40",
   "typings": "lib/index.d.ts",
   "types": "lib/index.d.ts",
   "main": "lib/index.js",

--- a/packages/dma-library/src/protocols/ajna/index.ts
+++ b/packages/dma-library/src/protocols/ajna/index.ts
@@ -431,6 +431,7 @@ export const calculateAjnaMaxLiquidityWithdraw = ({
         ...buckets.filter(bucket => !bucket.index.eq(lupBucket.index)),
         { ...lupBucket, quoteTokens: lupBucket.quoteTokens.minus(liquidityInLupBucket) },
       ].sort((a, b) => a.index.minus(b.index).toNumber()),
+      depositSize: pool.depositSize.minus(liquidityInLupBucket),
       lowestUtilizedPriceIndex: buckets[lupBucketIndex + 1].index,
       lowestUtilizedPrice: buckets[lupBucketIndex + 1].price,
     },

--- a/packages/dma-library/src/protocols/ajna/index.ts
+++ b/packages/dma-library/src/protocols/ajna/index.ts
@@ -229,9 +229,7 @@ export function calculateMaxGenerate(
 }
 
 export function calculateNewLup(pool: AjnaPool, debtChange: BigNumber): [BigNumber, BigNumber] {
-  const sortedBuckets = pool.buckets
-    .filter(bucket => bucket.index.lte(pool.highestThresholdPriceIndex))
-    .sort((a, b) => a.index.minus(b.index).toNumber())
+  const sortedBuckets = pool.buckets.sort((a, b) => a.index.minus(b.index).toNumber())
   const availablePoolLiquidity = getPoolLiquidity({
     buckets: pool.buckets,
     debt: pool.debt,

--- a/packages/dma-library/src/strategies/ajna/borrow/deposit-borrow.ts
+++ b/packages/dma-library/src/strategies/ajna/borrow/deposit-borrow.ts
@@ -11,9 +11,9 @@ import BigNumber from 'bignumber.js'
 import { ethers } from 'ethers'
 
 import {
-  // validateBorrowUndercollateralized,
+  validateBorrowUndercollateralized,
   validateDustLimit,
-  // validateLiquidity,
+  validateLiquidity,
 } from '../validation'
 import { validateGenerateCloseToMaxLtv } from '../validation/borrowish/closeToMaxLtv'
 
@@ -47,8 +47,8 @@ export const depositBorrow: AjnaDepositBorrowStrategy = async (args, dependencie
 
   const errors = [
     ...validateDustLimit(targetPosition),
-    // ...validateBorrowUndercollateralized(targetPosition, args.position, args.quoteAmount),
-    // ...validateLiquidity(targetPosition, args.position, args.quoteAmount),
+    ...validateBorrowUndercollateralized(targetPosition, args.position, args.quoteAmount),
+    ...validateLiquidity(targetPosition, args.position, args.quoteAmount),
   ]
 
   const warnings = [...validateGenerateCloseToMaxLtv(targetPosition, args.position)]

--- a/packages/dma-library/src/strategies/ajna/validation/borrowish/notEnoughLiquidity.ts
+++ b/packages/dma-library/src/strategies/ajna/validation/borrowish/notEnoughLiquidity.ts
@@ -29,14 +29,13 @@ export function validateLiquidity(
   borrowAmount: BigNumber,
 ): AjnaError[] {
   const availableLiquidity = getPoolLiquidity(positionBefore.pool)
-  const maxDebt = positionBefore.debtAvailable(position.collateralAmount)
 
   if (availableLiquidity.lt(borrowAmount)) {
     return [
       {
         name: 'not-enough-liquidity',
         data: {
-          amount: formatCryptoBalance(negativeToZero(maxDebt)),
+          amount: formatCryptoBalance(negativeToZero(availableLiquidity)),
         },
       },
     ]


### PR DESCRIPTION
[Bring back max generate calculations and validations](https://app.shortcut.com/oazo-apps/story/10369/fix-calculations-for-available-to-borrow-and-available-to-withdraw)

- adjusted max generate calculations
- enabled previously suppressed validations in for borrow positions
- fixed pool simulation method