### PR TITLE
Bring back max withdraw validation

### DIFF
--- a/packages/dma-library/package.json
+++ b/packages/dma-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oasisdex/dma-library",
-  "version": "0.3.40",
+  "version": "0.3.41",
   "typings": "lib/index.d.ts",
   "types": "lib/index.d.ts",
   "main": "lib/index.js",

--- a/packages/dma-library/src/strategies/ajna/borrow/payback-withdraw.ts
+++ b/packages/dma-library/src/strategies/ajna/borrow/payback-withdraw.ts
@@ -10,8 +10,8 @@ import { ethers } from 'ethers'
 
 import {
   validateDustLimit,
-  // validateOverWithdraw,
-  // validateWithdrawUndercollateralized,
+  validateOverWithdraw,
+  validateWithdrawUndercollateralized,
 } from '../validation'
 import { validateWithdrawCloseToMaxLtv } from '../validation/borrowish/closeToMaxLtv'
 
@@ -42,9 +42,8 @@ export const paybackWithdraw: AjnaPaybackWithdrawStrategy = async (args, depende
 
   const errors = [
     ...validateDustLimit(targetPosition),
-    // ...validateWithdrawUndercollateralized(targetPosition, args.position),
-    // ...validateOverWithdraw(targetPosition, args.position, args.collateralAmount),
-    // ...validateOverRepay(args.position, args.quoteAmount),
+    ...validateWithdrawUndercollateralized(targetPosition, args.position),
+    ...validateOverWithdraw(targetPosition, args.position, args.collateralAmount),
   ]
 
   const warnings = [...validateWithdrawCloseToMaxLtv(targetPosition, args.position)]


### PR DESCRIPTION
[Bring back max withdraw validation](https://app.shortcut.com/oazo-apps/story/10369/fix-calculations-for-available-to-borrow-and-available-to-withdraw)

- enabled previously suppressed validation when user tries to withdraw in ajna borrow position