### PR TITLE
Added liquidation price at t0 netural price

### DIFF
--- a/packages/dma-library/package.json
+++ b/packages/dma-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oasisdex/dma-library",
-  "version": "0.3.44",
+  "version": "0.3.45",
   "typings": "lib/index.d.ts",
   "types": "lib/index.d.ts",
   "main": "lib/index.js",

--- a/packages/dma-library/src/types/ajna/ajna-position.ts
+++ b/packages/dma-library/src/types/ajna/ajna-position.ts
@@ -21,6 +21,7 @@ export interface IAjnaPosition {
 
   marketPrice: BigNumber
   liquidationPrice: BigNumber
+  liquidationPriceT0Np: BigNumber
   liquidationToMarketPrice: BigNumber
   thresholdPrice: BigNumber
 
@@ -54,6 +55,7 @@ export class AjnaPosition implements IAjnaPosition {
     public debtAmount: BigNumber,
     public collateralPrice: BigNumber,
     public quotePrice: BigNumber,
+    public t0NeutralPrice: BigNumber,
   ) {}
 
   get liquidationPrice() {
@@ -64,12 +66,16 @@ export class AjnaPosition implements IAjnaPosition {
     })
   }
 
+  get liquidationPriceT0Np() {
+    return this.t0NeutralPrice.times(this.pool.pendingInflator)
+  }
+
   get marketPrice() {
     return this.collateralPrice.div(this.quotePrice)
   }
 
   get liquidationToMarketPrice() {
-    return this.liquidationPrice.div(this.marketPrice)
+    return this.liquidationPriceT0Np.div(this.marketPrice)
   }
 
   get thresholdPrice() {
@@ -136,6 +142,7 @@ export class AjnaPosition implements IAjnaPosition {
       this.debtAmount,
       this.collateralPrice,
       this.quotePrice,
+      this.t0NeutralPrice,
     )
   }
 
@@ -148,6 +155,7 @@ export class AjnaPosition implements IAjnaPosition {
       this.debtAmount,
       this.collateralPrice,
       this.quotePrice,
+      this.t0NeutralPrice,
     )
   }
 
@@ -160,6 +168,7 @@ export class AjnaPosition implements IAjnaPosition {
       newDebt,
       this.collateralPrice,
       this.quotePrice,
+      this.t0NeutralPrice,
     )
   }
 
@@ -172,6 +181,7 @@ export class AjnaPosition implements IAjnaPosition {
       newDebt,
       this.collateralPrice,
       this.quotePrice,
+      this.t0NeutralPrice,
     )
   }
 
@@ -183,6 +193,7 @@ export class AjnaPosition implements IAjnaPosition {
       ZERO,
       this.collateralPrice,
       this.quotePrice,
+      this.t0NeutralPrice,
     )
   }
 }

--- a/packages/dma-library/src/views/ajna/index.ts
+++ b/packages/dma-library/src/views/ajna/index.ts
@@ -65,6 +65,7 @@ export async function getPosition(
     new BigNumber(borrowerInfo.debt_.toString()).div(WAD),
     collateralPrice,
     quotePrice,
+    new BigNumber(borrowerInfo.t0Np_.toString()).div(WAD),
   )
 }
 


### PR DESCRIPTION
- added liquidation price at t0 netural price which is the value to be used in ajna borrow and multiply overview section