### PR TITLE
Adjust ajna generate close to max validation

### DIFF
--- a/packages/dma-library/package.json
+++ b/packages/dma-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oasisdex/dma-library",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "typings": "lib/index.d.ts",
   "types": "lib/index.d.ts",
   "main": "lib/index.js",

--- a/packages/dma-library/src/strategies/ajna/validation/borrowish/closeToMaxLtv.ts
+++ b/packages/dma-library/src/strategies/ajna/validation/borrowish/closeToMaxLtv.ts
@@ -7,7 +7,10 @@ export function validateGenerateCloseToMaxLtv(
   position: AjnaPosition,
   positionBefore: AjnaPosition,
 ): AjnaWarning[] {
-  if (position.maxRiskRatio.loanToValue.minus(MAX_LTV_OFFSET).lte(position.riskRatio.loanToValue)) {
+  if (
+    position.maxRiskRatio.loanToValue.minus(MAX_LTV_OFFSET).lte(position.riskRatio.loanToValue) &&
+    !positionBefore.debtAmount.eq(position.debtAmount)
+  ) {
     return [
       {
         name: 'generate-close-to-max-ltv',


### PR DESCRIPTION
## Ticket URL
https://app.shortcut.com/oazo-apps/story/10598/generate-close-to-max-ltv-shows-zeros

Please provide a link to the ticket:

## Description of Changes

- adjusted validation so warning is not displayed when position debt amount remain unchanged

Please list the changes introduced by this PR:

- adjusted `validateGenerateCloseToMaxLtv` method

## How to Test

Please provide instructions on how to test the changes in this PR:

- create either borrow or multiply position, generate enough debt to be within range of 5% to dynamic max ltv, try to deposit some more collateral -> in that case warning shouldn't be visible

## PR Definition of Done

Please ensure the following requirements have been met before marking the PR as ready for review:

- [ ] All checks are passing
- [ ] PR is linked to a corresponding ticket
- [ ] PR title is clear and concise
- [ ] Code has been self-reviewed and any fixes or improvements noted (See Code review standards in Notion)
- [ ] Documentation has been updated if necessary
