### PR TITLE
Update 1inch calls in the earn sc library repo to switch to a new 1inch API

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -31,3 +31,6 @@ SHEET_ID=Used for regenerating scenarios
 TENDERLY_PROJECT=oasis
 TENDERLY_FORK_URL=URL of the fork
 TENDERLY_FORK_CHAIN_ID=Chain ID of the fork
+
+## 1inch config
+ONE_INCH_API_KEY=Auth key for 1inch API

--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ yarn test:unit
 yarn test:e2e
 ```
 
-4. Run a specific test in the repo (example)
+4. Run a specific test in the specific package (example)
+_Command should be run from a respective package folder_
 
 ```shell
 yarn clean & yarn hardhat test <path-to-test>

--- a/packages/dma-common/test-utils/dummy-exchange.ts
+++ b/packages/dma-common/test-utils/dummy-exchange.ts
@@ -13,6 +13,8 @@ import { Contract, ethers, Signer } from 'ethers'
 import fetch from 'node-fetch'
 import { curry } from 'ramda'
 
+import { getOneInchAuthHeader, ONE_INCH_API_URL } from './1inch'
+
 export const FEE = 20
 export const FEE_BASE = 10000
 
@@ -30,9 +32,15 @@ export async function getMarketPrice(
   toPrecision = 18,
 ) {
   const amount = ethers.utils.parseUnits('0.1', fromPrecision)
-  const url = `https://api.1inch.exchange/v4.0/1/quote?fromTokenAddress=${from}&toTokenAddress=${to}&amount=${amount}&protocols=UNISWAP_V3`
+  const url = `${ONE_INCH_API_URL}/v4.0/1/quote?fromTokenAddress=${from}&toTokenAddress=${to}&amount=${amount}&protocols=UNISWAP_V3`
 
-  const response = await fetch(url)
+  const oneInchAuthHeader = getOneInchAuthHeader()
+
+  const response = await fetch(url, {
+    headers: {
+      ...oneInchAuthHeader,
+    },
+  })
 
   if (!response.ok) {
     throw new Error(`Error performing 1inch quote request ${url}: ${await response.text()}`)


### PR DESCRIPTION
## Ticket URL

https://app.shortcut.com/oazo-apps/story/10478/update-1inch-calls-in-the-earn-sc-library-repo-to-switch-to-a-new-1inch-api

## Description of Changes

Please list the changes introduced by this PR:

Updated outdated 1inch api urls and added authentication header to api calls read from the ENV- [ ]

## How to Test

Please provide instructions on how to test the changes in this PR:

Run Swap Test

## PR Definition of Done

Please ensure the following requirements have been met before marking the PR as ready for review:

- [ ] All checks are passing
- [x] PR is linked to a corresponding ticket
- [x] PR title is clear and concise
- [x] Code has been self-reviewed and any fixes or improvements noted (See Code review standards in Notion)
- [x] Documentation has been updated if necessary
