### PR TITLE
feat: add stamploan to `repayDebt` - ajna

### DIFF
--- a/packages/ajna-contracts/contracts/ajna/ajna-actions/AjnaProxyActions.sol
+++ b/packages/ajna-contracts/contracts/ajna/ajna-actions/AjnaProxyActions.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.18;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { IERC721 } from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
 import { IAjnaPoolUtilsInfo } from "../../interfaces/ajna/IAjnaPoolUtilsInfo.sol";
 import { IERC20Pool } from "../interfaces/pool/erc20/IERC20Pool.sol";
@@ -31,6 +32,8 @@ contract AjnaProxyActions is IAjnaProxyActions {
     IPositionManager public positionManager;
     IRewardsManager public rewardsManager;
     address public ARC;
+
+    using SafeERC20 for IERC20;
 
     constructor(IAjnaPoolUtilsInfo _poolInfoUtils, IERC20 _ajnaToken, address _WETH, address _GUARD) {
         poolInfoUtils = _poolInfoUtils;
@@ -79,7 +82,7 @@ contract AjnaProxyActions is IAjnaProxyActions {
             IWETH(WETH).withdraw(amount);
             payable(msg.sender).transfer(amount);
         } else {
-            IERC20(token).transfer(msg.sender, amount);
+            IERC20(token).safeTransfer(msg.sender, amount);
         }
     }
 
@@ -87,7 +90,7 @@ contract AjnaProxyActions is IAjnaProxyActions {
         if (token == WETH) {
             IWETH(WETH).deposit{ value: amount }();
         } else {
-            IERC20(token).transferFrom(msg.sender, address(this), amount);
+            IERC20(token).safeTransferFrom(msg.sender, address(this), amount);
         }
     }
 
@@ -174,7 +177,7 @@ contract AjnaProxyActions is IAjnaProxyActions {
         address debtToken = pool.quoteTokenAddress();
         _pull(debtToken, amount);
         uint256 index = convertPriceToIndex(price);
-        IERC20(debtToken).approve(address(pool), amount);
+        IERC20(debtToken).safeApprove(address(pool), amount);
         pool.addQuoteToken(amount * pool.quoteTokenScale(), index, block.timestamp + 1, revertIfBelowLup);
     }
 
@@ -244,7 +247,7 @@ contract AjnaProxyActions is IAjnaProxyActions {
         _pull(collateralToken, collateralAmount);
 
         uint256 index = convertPriceToIndex(price);
-        IERC20(collateralToken).approve(address(pool), collateralAmount);
+        IERC20(collateralToken).safeApprove(address(pool), collateralAmount);
         pool.drawDebt(address(this), 0, index, collateralAmount * pool.collateralScale());
         emit ProxyActionsOperation("AjnaDeposit");
     }
@@ -281,7 +284,7 @@ contract AjnaProxyActions is IAjnaProxyActions {
         address collateralToken = pool.collateralAddress();
         uint256 index = convertPriceToIndex(price);
         _pull(collateralToken, collateralAmount);
-        IERC20(collateralToken).approve(address(pool), collateralAmount);
+        IERC20(collateralToken).safeApprove(address(pool), collateralAmount);
         pool.drawDebt(
             address(this),
             debtAmount * pool.quoteTokenScale(),
@@ -319,13 +322,15 @@ contract AjnaProxyActions is IAjnaProxyActions {
      *  @param  pool           Pool address
      *  @param  amount         Amount of debt to repay
      */
-    function repayDebt(IERC20Pool pool, uint256 amount) public payable {
+    function repayDebt(IERC20Pool pool, uint256 amount, bool stamploan) public payable {
         address debtToken = pool.quoteTokenAddress();
         _pull(debtToken, amount);
-        IERC20(debtToken).approve(address(pool), amount);
+        IERC20(debtToken).safeApprove(address(pool), amount);
         (, , , , , uint256 lupIndex_) = poolInfoUtils.poolPricesInfo(address(pool));
         pool.repayDebt(address(this), amount * pool.quoteTokenScale(), 0, address(this), lupIndex_);
-        pool.stampLoan();
+        if (stamploan) {
+            pool.stampLoan();
+        }
         emit ProxyActionsOperation("AjnaRepay");
     }
 
@@ -352,7 +357,7 @@ contract AjnaProxyActions is IAjnaProxyActions {
         address debtToken = pool.quoteTokenAddress();
         address collateralToken = pool.collateralAddress();
         _pull(debtToken, debtAmount);
-        IERC20(debtToken).approve(address(pool), debtAmount);
+        IERC20(debtToken).safeApprove(address(pool), debtAmount);
         (, , , , , uint256 lupIndex_) = poolInfoUtils.poolPricesInfo(address(pool));
         pool.repayDebt(
             address(this),
@@ -371,11 +376,16 @@ contract AjnaProxyActions is IAjnaProxyActions {
      *  @param  debtAmount     Amount of debt to repay
      *  @param  collateralAmount Amount of collateral to withdraw
      */
-    function repayWithdraw(IERC20Pool pool, uint256 debtAmount, uint256 collateralAmount) external payable {
+    function repayWithdraw(
+        IERC20Pool pool,
+        uint256 debtAmount,
+        uint256 collateralAmount,
+        bool stamploan
+    ) external payable {
         if (debtAmount > 0 && collateralAmount > 0) {
             repayDebtAndWithdrawCollateral(pool, debtAmount, collateralAmount);
         } else if (debtAmount > 0) {
-            repayDebt(pool, debtAmount);
+            repayDebt(pool, debtAmount, stamploan);
         } else if (collateralAmount > 0) {
             withdrawCollateral(pool, collateralAmount);
         }
@@ -394,7 +404,7 @@ contract AjnaProxyActions is IAjnaProxyActions {
         uint256 amountDebt = debtPlusBuffer / pool.quoteTokenScale();
         _pull(debtToken, amountDebt);
 
-        IERC20(debtToken).approve(address(pool), amountDebt);
+        IERC20(debtToken).safeApprove(address(pool), amountDebt);
         (, , , , , uint256 lupIndex_) = poolInfoUtils.poolPricesInfo(address(pool));
         pool.repayDebt(address(this), debtPlusBuffer, collateral, address(this), lupIndex_);
 

--- a/packages/ajna-contracts/contracts/ajna/ajna-actions/AjnaProxyActions.sol
+++ b/packages/ajna-contracts/contracts/ajna/ajna-actions/AjnaProxyActions.sol
@@ -325,6 +325,7 @@ contract AjnaProxyActions is IAjnaProxyActions {
         IERC20(debtToken).approve(address(pool), amount);
         (, , , , , uint256 lupIndex_) = poolInfoUtils.poolPricesInfo(address(pool));
         pool.repayDebt(address(this), amount * pool.quoteTokenScale(), 0, address(this), lupIndex_);
+        pool.stampLoan();
         emit ProxyActionsOperation("AjnaRepay");
     }
 
@@ -375,7 +376,6 @@ contract AjnaProxyActions is IAjnaProxyActions {
             repayDebtAndWithdrawCollateral(pool, debtAmount, collateralAmount);
         } else if (debtAmount > 0) {
             repayDebt(pool, debtAmount);
-            pool.stampLoan();
         } else if (collateralAmount > 0) {
             withdrawCollateral(pool, collateralAmount);
         }

--- a/packages/ajna-contracts/contracts/ajna/ajna-actions/AjnaProxyActions.sol
+++ b/packages/ajna-contracts/contracts/ajna/ajna-actions/AjnaProxyActions.sol
@@ -375,6 +375,7 @@ contract AjnaProxyActions is IAjnaProxyActions {
             repayDebtAndWithdrawCollateral(pool, debtAmount, collateralAmount);
         } else if (debtAmount > 0) {
             repayDebt(pool, debtAmount);
+            pool.stampLoan();
         } else if (collateralAmount > 0) {
             withdrawCollateral(pool, collateralAmount);
         }

--- a/packages/ajna-contracts/contracts/ajna/ajna-actions/AjnaProxyActions.sol
+++ b/packages/ajna-contracts/contracts/ajna/ajna-actions/AjnaProxyActions.sol
@@ -321,6 +321,7 @@ contract AjnaProxyActions is IAjnaProxyActions {
      *  @notice Repay debt
      *  @param  pool           Pool address
      *  @param  amount         Amount of debt to repay
+     *  @param  stamploan      Whether to stamp the loan or not
      */
     function repayDebt(IERC20Pool pool, uint256 amount, bool stamploan) public payable {
         address debtToken = pool.quoteTokenAddress();
@@ -375,6 +376,7 @@ contract AjnaProxyActions is IAjnaProxyActions {
      *  @param  pool           Pool address
      *  @param  debtAmount     Amount of debt to repay
      *  @param  collateralAmount Amount of collateral to withdraw
+     *  @param  stamploan      Whether to stamp the loan or not
      */
     function repayWithdraw(
         IERC20Pool pool,

--- a/packages/ajna-contracts/scripts/common/config.ts
+++ b/packages/ajna-contracts/scripts/common/config.ts
@@ -67,4 +67,5 @@ export const CONFIG = {
   initializeStakingRewards: false,
   deployPools: true,
   deployer: "0x8E78CC7089509B568a401f593F64B3074693d25E",
+  logGasUsage: false,
 };

--- a/packages/ajna-contracts/scripts/common/hardhat.utils.ts
+++ b/packages/ajna-contracts/scripts/common/hardhat.utils.ts
@@ -10,6 +10,7 @@ import { HardhatRuntimeEnvironment, Network } from "hardhat/types/runtime";
 import { join } from "path";
 
 import { Token, WETH } from "../../typechain-types";
+import { CONFIG } from "./config";
 
 export type BasicSimulationData = {
   data: string;
@@ -223,4 +224,8 @@ export class HardhatUtils {
       return false;
     }
   }
+}
+
+export function logGasUsage(receipt: ContractReceipt, methodName: string) {
+  CONFIG.logGasUsage ? console.log(`gas used ${methodName}`, receipt.gasUsed.toString()) : null;
 }

--- a/packages/ajna-contracts/test/pool.dpm.test.ts
+++ b/packages/ajna-contracts/test/pool.dpm.test.ts
@@ -44,7 +44,7 @@ describe.only("AjnaProxyActions", function () {
     });
     const [deployer, lender, borrower, bidder] = await hre.ethers.getSigners();
 
-    const { usdc, wbtc, ajna, weth } = await deployTokens(deployer.address);
+    const { usdc, wbtc, ajna, weth } = await deployTokens(deployer.address, false);
 
     const {
       poolCommons,
@@ -57,7 +57,7 @@ describe.only("AjnaProxyActions", function () {
       lenderActionsInstance,
     } = await deployLibraries();
 
-    const { dmpGuardContract, guardDeployerSigner, dmpFactory } = await deployGuard(hre);
+    const { dmpGuardContract, guardDeployerSigner, dmpFactory } = await deployGuard();
 
     const { erc20PoolFactory, erc721PoolFactory } = await deployPoolFactory(
       poolCommons,
@@ -67,19 +67,17 @@ describe.only("AjnaProxyActions", function () {
       takerActionsInstance,
       lpActionsInstance,
       lenderActionsInstance,
-      ajna.address,
-      hre
+      ajna.address
     );
     const [poolContract, poolContractWeth] = await Promise.all([
-      deployPool(erc20PoolFactory, wbtc.address, usdc.address, hre),
-      deployPool(erc20PoolFactory, weth.address, usdc.address, hre),
+      deployPool(erc20PoolFactory, wbtc.address, usdc.address),
+      deployPool(erc20PoolFactory, weth.address, usdc.address),
     ]);
     const { rewardsManagerContract, positionManagerContract } = await deployRewardsContracts(
       positionNFTSVGInstance,
       erc20PoolFactory,
       erc721PoolFactory,
-      ajna,
-      hre
+      ajna
     );
     const { ajnaProxyActionsContract, poolInfoContract, ajnaRewardsClaimerContract } = await deployApa(
       poolCommons,
@@ -89,7 +87,6 @@ describe.only("AjnaProxyActions", function () {
       guardDeployerSigner,
       weth,
       ajna,
-      hre,
       initializeStaking
     );
 

--- a/packages/ajna-contracts/test/pool.dpm.test.ts
+++ b/packages/ajna-contracts/test/pool.dpm.test.ts
@@ -16,7 +16,7 @@ import {
   PoolInfoUtils,
 } from "@oasisdex/ajna-contracts/typechain-types";
 import { expect } from "chai";
-import { BigNumber, ContractReceipt, Signer } from "ethers";
+import { BigNumber, Signer } from "ethers";
 import hre, { ethers } from "hardhat";
 
 import { bn } from "../scripts/common";
@@ -24,7 +24,6 @@ import { HardhatUtils, logGasUsage } from "../scripts/common/hardhat.utils";
 import { createDPMProxy } from "../scripts/prepare-env";
 import { ERC20 } from "../typechain-types/@openzeppelin/contracts/token/ERC20/";
 import { WETH as WETHContract } from "../typechain-types/contracts/ajna";
-import { CONFIG } from "@ajna-contracts/scripts/common/config";
 
 const utils = new HardhatUtils(hre);
 const addresses: { [key: string]: string } = {};

--- a/yarn.lock
+++ b/yarn.lock
@@ -10682,6 +10682,27 @@ inquirer@8.2.4:
     through "^2.3.6"
     wrap-ansi "^7.0.0"
 
+inquirer@^8.0.0:
+  version "8.2.6"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-8.2.6.tgz#733b74888195d8d400a67ac332011b5fae5ea562"
+  integrity sha512-M1WuAmb7pn9zdFRtQYk26ZBoY043Sse0wVDdk4Bppr+JOXyQYybdtvK+l9wUibhtjdjvtoiNy8tk+EgsYIUqKg==
+  dependencies:
+    ansi-escapes "^4.2.1"
+    chalk "^4.1.1"
+    cli-cursor "^3.1.0"
+    cli-width "^3.0.0"
+    external-editor "^3.0.3"
+    figures "^3.0.0"
+    lodash "^4.17.21"
+    mute-stream "0.0.8"
+    ora "^5.4.1"
+    run-async "^2.4.0"
+    rxjs "^7.5.5"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+    through "^2.3.6"
+    wrap-ansi "^6.0.1"
+
 inquirer@^8.2.4:
   version "8.2.5"
   resolved "https://registry.npmjs.org/inquirer/-/inquirer-8.2.5.tgz"
@@ -18502,6 +18523,15 @@ wrap-ansi@^5.1.0:
     ansi-styles "^3.2.0"
     string-width "^3.0.0"
     strip-ansi "^5.0.0"
+
+wrap-ansi@^6.0.1:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
+  integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
 
 wrap-ansi@^7.0.0:
   version "7.0.0"


### PR DESCRIPTION
## [sc-11355] [sc-11377]

Please provide a link to the ticket:
![image](https://github.com/OasisDEX/oasis-earn-sc/assets/6533433/a5c25df7-0627-4cf0-a8e8-ff95ba53d66e)

## Description of Changes

Please list the changes introduced by this PR:

- added optional `stampLoan` flag in `repayDebt`
-  change transfers to use `safeERC20` in order to support non-ERC20 compliant tokens like `USDT`
- added `logGasUsage` method to easily log contract method gas usage if it's enabled in the config.

## How to Test

run tests

## PR Definition of Done

Please ensure the following requirements have been met before marking the PR as ready for review:

- [x] All checks are passing
- [x] PR is linked to a corresponding ticket
- [x] PR title is clear and concise
- [x] Code has been self-reviewed and any fixes or improvements noted (See Code review standards in Notion)
- [ ] Documentation has been updated if necessary
