### PR TITLE
Add yieldETH and yieldBTC tokens to config

### DIFF
--- a/packages/addresses/package.json
+++ b/packages/addresses/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oasisdex/addresses",
-  "version": "0.0.41",
+  "version": "0.0.42",
   "typings": "lib/index.d.ts",
   "types": "lib/index.d.ts",
   "main": "lib/index.js",

--- a/packages/deploy-configurations/configs/arbitrum.conf.ts
+++ b/packages/deploy-configurations/configs/arbitrum.conf.ts
@@ -412,6 +412,14 @@ export const config: SystemConfig = {
       address: '0x5979D7b546E38E414F7E9822514be443A4800529',
       serviceRegistryName: SERVICE_REGISTRY_NAMES.common.WSTETH,
     },
+    YIELDBTC: {
+      name: 'YIELDBTC',
+      address: ADDRESS_ZERO,
+    },
+    YIELDETH: {
+      name: 'YIELDETH',
+      address: ADDRESS_ZERO,
+    },
     YFI: { name: 'YFI', address: ADDRESS_ZERO },
     ZRX: { name: 'ZRX', address: ADDRESS_ZERO },
   },

--- a/packages/deploy-configurations/configs/goerli.conf.ts
+++ b/packages/deploy-configurations/configs/goerli.conf.ts
@@ -440,6 +440,14 @@ export const config: SystemConfig = {
       address: '0x6320cD32aA674d2898A68ec82e869385Fc5f7E2f',
       serviceRegistryName: 'WSTETH',
     },
+    YIELDBTC: {
+      name: 'YIELDBTC',
+      address: ADDRESS_ZERO,
+    },
+    YIELDETH: {
+      name: 'YIELDETH',
+      address: ADDRESS_ZERO,
+    },
     YFI: { name: 'YFI', address: '0xd9510EF268F8273C9b7514F0bfFe18Fe1EFC0d43' },
     ZRX: { name: 'ZRX', address: '0x96E0C18524789ED3e62CD9F56aAEc7cEAC78725a' },
   },

--- a/packages/deploy-configurations/configs/hardhat.conf.ts
+++ b/packages/deploy-configurations/configs/hardhat.conf.ts
@@ -582,6 +582,14 @@ export const config: SystemConfig = {
       address: '0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0',
       serviceRegistryName: SERVICE_REGISTRY_NAMES.common.WSTETH,
     },
+    YIELDBTC: {
+      name: 'YIELDBTC',
+      address: ADDRESS_ZERO,
+    },
+    YIELDETH: {
+      name: 'YIELDETH',
+      address: ADDRESS_ZERO,
+    },
     YFI: {
       name: 'YFI',
       address: '0x0bc529c00C6401aEF6D220BE8C6Ea1667F6Ad93e',

--- a/packages/deploy-configurations/configs/local.conf.ts
+++ b/packages/deploy-configurations/configs/local.conf.ts
@@ -594,6 +594,14 @@ export const config: SystemConfig = {
       address: '0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0',
       serviceRegistryName: SERVICE_REGISTRY_NAMES.common.WSTETH,
     },
+    YIELDBTC: {
+      name: 'YIELDBTC',
+      address: '0x0274a704a6d9129f90a62ddc6f6024b33ecdad36',
+    },
+    YIELDETH: {
+      name: 'YIELDETH',
+      address: '0xb5b29320d2dde5ba5bafa1ebcd270052070483ec',
+    },
     YFI: {
       name: 'YFI',
       address: '0x0bc529c00C6401aEF6D220BE8C6Ea1667F6Ad93e',

--- a/packages/deploy-configurations/configs/mainnet.conf.ts
+++ b/packages/deploy-configurations/configs/mainnet.conf.ts
@@ -580,6 +580,14 @@ export const config: SystemConfig = {
       address: '0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0',
       serviceRegistryName: SERVICE_REGISTRY_NAMES.common.WSTETH,
     },
+    YIELDBTC: {
+      name: 'YIELDBTC',
+      address: '0x0274a704a6d9129f90a62ddc6f6024b33ecdad36',
+    },
+    YIELDETH: {
+      name: 'YIELDETH',
+      address: '0xb5b29320d2dde5ba5bafa1ebcd270052070483ec',
+    },
     YFI: {
       name: 'YFI',
       address: '0x0bc529c00C6401aEF6D220BE8C6Ea1667F6Ad93e',

--- a/packages/deploy-configurations/configs/optimism.conf.ts
+++ b/packages/deploy-configurations/configs/optimism.conf.ts
@@ -425,6 +425,14 @@ export const config: SystemConfig = {
       address: '0x1F32b1c2345538c0c6f582fCB022739c4A194Ebb',
       serviceRegistryName: SERVICE_REGISTRY_NAMES.common.WSTETH,
     },
+    YIELDBTC: {
+      name: 'YIELDBTC',
+      address: ADDRESS_ZERO,
+    },
+    YIELDETH: {
+      name: 'YIELDETH',
+      address: ADDRESS_ZERO,
+    },
     YFI: { name: 'YFI', address: ADDRESS_ZERO },
     ZRX: { name: 'ZRX', address: ADDRESS_ZERO },
   },

--- a/packages/deploy-configurations/configs/tenderly.conf.ts
+++ b/packages/deploy-configurations/configs/tenderly.conf.ts
@@ -652,6 +652,14 @@ export const config: SystemConfig = {
       address: '0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0',
       serviceRegistryName: SERVICE_REGISTRY_NAMES.common.WSTETH,
     },
+    YIELDBTC: {
+      name: 'YIELDBTC',
+      address: '0x0274a704a6d9129f90a62ddc6f6024b33ecdad36',
+    },
+    YIELDETH: {
+      name: 'YIELDETH',
+      address: '0xb5b29320d2dde5ba5bafa1ebcd270052070483ec',
+    },
     YFI: {
       name: 'YFI',
       address: '0x0bc529c00C6401aEF6D220BE8C6Ea1667F6Ad93e',

--- a/packages/deploy-configurations/configs/test/mainnet.conf.ts
+++ b/packages/deploy-configurations/configs/test/mainnet.conf.ts
@@ -466,6 +466,14 @@ export const config: SystemConfig = {
       address: '0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0',
       serviceRegistryName: SERVICE_REGISTRY_NAMES.common.WSTETH,
     },
+    YIELDBTC: {
+      name: 'YIELDBTC',
+      address: '0x0274a704a6d9129f90a62ddc6f6024b33ecdad36',
+    },
+    YIELDETH: {
+      name: 'YIELDETH',
+      address: '0xb5b29320d2dde5ba5bafa1ebcd270052070483ec',
+    },
     YFI: { name: 'YFI', address: '0x0bc529c00C6401aEF6D220BE8C6Ea1667F6Ad93e' },
     ZRX: { name: 'ZRX', address: '0xE41d2489571d322189246DaFA5ebDe1F4699F498' },
   },

--- a/packages/deploy-configurations/configs/test/optimism.conf.ts
+++ b/packages/deploy-configurations/configs/test/optimism.conf.ts
@@ -420,6 +420,14 @@ export const config: SystemConfig = {
       address: '0x1F32b1c2345538c0c6f582fCB022739c4A194Ebb',
       serviceRegistryName: SERVICE_REGISTRY_NAMES.common.WSTETH,
     },
+    YIELDBTC: {
+      name: 'YIELDBTC',
+      address: ADDRESS_ZERO,
+    },
+    YIELDETH: {
+      name: 'YIELDETH',
+      address: ADDRESS_ZERO,
+    },
     YFI: { name: 'YFI', address: ADDRESS_ZERO },
     ZRX: { name: 'ZRX', address: ADDRESS_ZERO },
   },

--- a/packages/deploy-configurations/types/deployment-config.ts
+++ b/packages/deploy-configurations/types/deployment-config.ts
@@ -104,6 +104,8 @@ export type Tokens =
   | 'WETH'
   | 'WLD'
   | 'WSTETH'
+  | 'YIELDBTC'
+  | 'YIELDETH'
   | 'YFI'
   | 'ZRX'
 


### PR DESCRIPTION
## Add yieldETH and yieldBTC tokens to config

https://app.shortcut.com/oazo-apps/story/11208/allow-summer-fi-to-show-oracle-less-pools-in-main-product-finder

## Description of Changes

- Added addresses of yieldETH and yieldBTC to library.

## PR Definition of Done

Please ensure the following requirements have been met before marking the PR as ready for review:

- [x] All checks are passing
- [x] PR is linked to a corresponding ticket
- [x] PR title is clear and concise
- [x] Code has been self-reviewed and any fixes or improvements noted (See Code review standards in Notion)
- [x] Documentation has been updated if necessary
