### PR TITLE
Initial max debt is negative check

### DIFF
--- a/packages/dma-library/package.json
+++ b/packages/dma-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oasisdex/dma-library",
-  "version": "0.4.11",
+  "version": "0.4.12",
   "typings": "lib/index.d.ts",
   "types": "lib/index.d.ts",
   "main": "lib/index.js",


### PR DESCRIPTION
## [Initial max debt is negative check](https://app.shortcut.com/oazo-apps/story/11297/available-to-borrow-is-calculating-a-wrong-value-for-one-position)

Please provide a link to the ticket:

## Description of Changes

Please list the changes introduced by this PR:

- added check whether initial max debt value is negative

## How to Test

- position `ethereum/ajna/1223#overview` max generate should be way above 0. At this moment, base on the pool state it should be ~31k

## PR Definition of Done

Please ensure the following requirements have been met before marking the PR as ready for review:

- [x] All checks are passing
- [x] PR is linked to a corresponding ticket
- [x] PR title is clear and concise
- [x] Code has been self-reviewed and any fixes or improvements noted (See Code review standards in Notion)
- [x] Documentation has been updated if necessary
