### PR TITLE
feat: check leftover quote token in proxy after repay

### DIFF
--- a/packages/ajna-contracts/scripts/common/config.ts
+++ b/packages/ajna-contracts/scripts/common/config.ts
@@ -67,5 +67,5 @@ export const CONFIG = {
   initializeStakingRewards: false,
   deployPools: false,
   deployer: "0x8E78CC7089509B568a401f593F64B3074693d25E",
-  logGasUsage: false,
+  logGasUsage: true,
 };


### PR DESCRIPTION
## Ticket URL

[sc-11421]

## Description of Changes

Additional checks were added to:
- check if the entire reapy amount has been used to repay debt
- if not - the leftover amount is sent back to the proxy owner
- sine we zero the proxy balance, we gained some gas savings

Affected methods :
- `repayDebt`
- `repayDebtAndWithdrawCollateral`

## How to Test

Please provide instructions on how to test the changes in this PR:

## PR Definition of Done

Please ensure the following requirements have been met before marking the PR as ready for review:

- [ ] All checks are passing
- [ ] PR is linked to a corresponding ticket
- [ ] PR title is clear and concise
- [ ] Code has been self-reviewed and any fixes or improvements noted (See Code review standards in Notion)
- [ ] Documentation has been updated if necessary
