### PR TITLE
[fix] tokens type patch

### DIFF
--- a/packages/addresses/package.json
+++ b/packages/addresses/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oasisdex/addresses",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "typings": "lib/index.d.ts",
   "types": "lib/index.d.ts",
   "main": "lib/index.js",

--- a/packages/dma-library/package.json
+++ b/packages/dma-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oasisdex/dma-library",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "typings": "lib/index.d.ts",
   "types": "lib/index.d.ts",
   "main": "lib/index.js",

--- a/packages/dma-library/src/types/aave-like/tokens.ts
+++ b/packages/dma-library/src/types/aave-like/tokens.ts
@@ -1,3 +1,3 @@
 import { Tokens } from '@deploy-configurations/types/deployment-config'
 
-export type AaveLikeTokens = Tokens
+export type AaveLikeTokens = Tokens | 'ETH'


### PR DESCRIPTION
Fix AaveLikeTokens in lib to include `ETH` so it can be passed as symbol from FE