### PR TITLE
Add sDAI to correlated asset matrix

### DIFF
--- a/packages/dma-library/package.json
+++ b/packages/dma-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oasisdex/dma-library",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "typings": "lib/index.d.ts",
   "types": "lib/index.d.ts",
   "main": "lib/index.js",

--- a/packages/dma-library/src/utils/swap/fee-resolver.ts
+++ b/packages/dma-library/src/utils/swap/fee-resolver.ts
@@ -47,7 +47,7 @@ export function isCorrelatedPosition(symbolA: string, symbolB: string) {
   const correlatedAssetMatrix = [
     ['ETH', 'WSTETH', 'CBETH', 'RETH', 'STETH'], // ETH correlated assets
     ['WBTC', 'TBTC'], // BTC correlated assets
-    ['USDC', 'DAI', 'GHO'], // USDC correlated assets
+    ['USDC', 'DAI', 'GHO', 'SDAI'], // USDC correlated assets
     // Add more arrays here to expand the matrix in the future
   ]
 


### PR DESCRIPTION
## [Add sDAI to correlated asset matrix](https://app.shortcut.com/oazo-apps/story/11641/update-fee-model-for-sdai-usdc-multiply-product)

## Description of Changes

-  added sDai to correlated position matrix so when sDAI will be used in pair with for example USDC, a reduced swap fees will be used for actions like decrease multiply or close

## How to Test

- no fees when increasing risk for sDAI/USDC pair on Ajna
- reduced fees when decreasing risk or closing position

## PR Definition of Done

Please ensure the following requirements have been met before marking the PR as ready for review:

- [x] All checks are passing
- [x] PR is linked to a corresponding ticket
- [x] PR title is clear and concise
- [x] Code has been self-reviewed and any fixes or improvements noted (See Code review standards in Notion)
- [x] Documentation has been updated if necessary
