### PR TITLE
Neutral price simulation

### DIFF
--- a/packages/dma-library/src/index.ts
+++ b/packages/dma-library/src/index.ts
@@ -7,12 +7,7 @@ export { operations } from './operations'
 export { OPERATION_NAMES } from '@deploy-configurations/constants'
 
 // PROTOCOLS
-export {
-  calculateAjnaApyPerDays,
-  calculateAjnaMaxLiquidityWithdraw,
-  getAjnaLiquidationPrice,
-  protocols,
-} from './protocols'
+export { calculateAjnaApyPerDays, calculateAjnaMaxLiquidityWithdraw, protocols } from './protocols'
 
 // STRATEGIES
 export { strategies } from './strategies'

--- a/packages/dma-library/src/protocols/index.ts
+++ b/packages/dma-library/src/protocols/index.ts
@@ -32,4 +32,4 @@ export { AaveProtocolData, AaveProtocolDataArgs }
 export { SparkProtocolData }
 
 export { calculateAjnaApyPerDays }
-export { calculateAjnaMaxLiquidityWithdraw, getAjnaLiquidationPrice } from './ajna/index'
+export { calculateAjnaMaxLiquidityWithdraw } from './ajna/index'

--- a/packages/dma-library/src/types/ajna/ajna-pool.ts
+++ b/packages/dma-library/src/types/ajna/ajna-pool.ts
@@ -46,4 +46,6 @@ export interface AjnaPool {
   currentBurnEpoch: BigNumber
   buckets: Bucket[]
   pendingInflator: BigNumber
+  loansCount: BigNumber
+  totalAuctionsInPool: BigNumber
 }

--- a/packages/dma-library/src/types/ajna/ajna-pool.ts
+++ b/packages/dma-library/src/types/ajna/ajna-pool.ts
@@ -48,4 +48,5 @@ export interface AjnaPool {
   pendingInflator: BigNumber
   loansCount: BigNumber
   totalAuctionsInPool: BigNumber
+  t0debt: BigNumber
 }


### PR DESCRIPTION
## [Neutral price simulation](https://app.shortcut.com/oazo-apps/story/10496/neutral-price-simulation-is-wrong)

Please provide a link to the ticket:

## Description of Changes

Please list the changes introduced by this PR:

- added method for calculating neutral price for simulation purposes

## How to Test

- liquidation price (which is based on netural price) simulation should be more or less in line with the liquidation price after action is performed

## PR Definition of Done

Please ensure the following requirements have been met before marking the PR as ready for review:

- [x] All checks are passing
- [x] PR is linked to a corresponding ticket
- [x] PR title is clear and concise
- [x] Code has been self-reviewed and any fixes or improvements noted (See Code review standards in Notion)
- [ ] Documentation has been updated if necessary
