### PR TITLE
:bug: bug(P1) Aave v3 - close operation - first withdraw only for cover swap

### DIFF
--- a/packages/dma-library/package.json
+++ b/packages/dma-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oasisdex/dma-library",
-  "version": "0.5.15",
+  "version": "0.5.16",
   "typings": "lib/index.d.ts",
   "types": "lib/index.d.ts",
   "main": "lib/index.js",

--- a/packages/dma-library/src/operations/aave/multiply/v3/close.ts
+++ b/packages/dma-library/src/operations/aave/multiply/v3/close.ts
@@ -62,14 +62,14 @@ export const close: AaveV3CloseOperation = async ({
     sumAmounts: false,
   })
 
-  const collateralToWithdraw =
-    collateral.address === flashloan.token.address
-      ? collateralAmountToBeSwapped
-      : new BigNumber(MAX_UINT)
+  // const collateralToWithdraw =
+  //   collateral.address === flashloan.token.address
+  //     ? collateralAmountToBeSwapped
+  //     : new BigNumber(MAX_UINT)
 
   const withdrawCollateralFromAAVE = actions.aave.v3.aaveV3Withdraw(network, {
     asset: collateral.address,
-    amount: collateralToWithdraw,
+    amount: collateralAmountToBeSwapped,
     to: proxy.address,
   })
 
@@ -106,6 +106,9 @@ export const close: AaveV3CloseOperation = async ({
     amount: flashloan.token.amount,
     to: addresses.operationExecutor,
   })
+
+  // const shouldWithdrawCollateralSecondTime = !collateralToWithdraw.eq(MAX_UINT)
+  // const secondWithdrawalAmount = shouldWithdrawCollateralSecondTime ? new BigNumber(MAX_UINT) : ZERO
 
   const withdrawCollateral = actions.aave.v3.aaveV3Withdraw(network, {
     asset: collateral.address,

--- a/packages/dma-library/src/operations/aave/multiply/v3/close.ts
+++ b/packages/dma-library/src/operations/aave/multiply/v3/close.ts
@@ -107,9 +107,6 @@ export const close: AaveV3CloseOperation = async ({
     to: addresses.operationExecutor,
   })
 
-  // const shouldWithdrawCollateralSecondTime = !collateralToWithdraw.eq(MAX_UINT)
-  // const secondWithdrawalAmount = shouldWithdrawCollateralSecondTime ? new BigNumber(MAX_UINT) : ZERO
-
   const withdrawCollateral = actions.aave.v3.aaveV3Withdraw(network, {
     asset: collateral.address,
     amount: new BigNumber(MAX_UINT),


### PR DESCRIPTION
Since we don't have the same tokens for flash loan and collateral, we are withdrawing the max amount in the first step. So, the second collateral withdrawal has nothing to get, and that's our error.

--- 
Packages:
@dma-library: 0.5.16