### PR TITLE
feat: add change ownership tool

### DIFF
--- a/packages/dma-contracts/hardhat.config.ts
+++ b/packages/dma-contracts/hardhat.config.ts
@@ -36,5 +36,6 @@ import './tasks/generate-op-tuple'
 import './tasks/get-action-name'
 import './tasks/service-registry'
 import './tasks/operations-registry'
+import './tasks/ownership-tool'
 
 export { default } from './hardhat.config.base'

--- a/packages/dma-contracts/package.json
+++ b/packages/dma-contracts/package.json
@@ -30,7 +30,9 @@
     "service:showlocal": "npx hardhat service-registry --showlocal",
     "service:showremote": "npx hardhat service-registry --showremote",
     "service:pushconfig": "npx hardhat service-registry --pushconfig",
-    "service:help": "npx hardhat service-registry --help"
+    "service:help": "npx hardhat service-registry --help",
+    "system:checkowners": "npx hardhat ownership-tool",
+    "system:changeowners": "npx hardhat ownership-tool --changeowners"
   },
   "dependencies": {
     "@openzeppelin/contracts": "^4.9.3",
@@ -40,6 +42,7 @@
     "tsconfig.json"
   ],
   "devDependencies": {
+    "@inquirer/prompts": "^3.2.0",
     "@tenderly/hardhat-tenderly": "^1.7.7",
     "console-log-colors": "^0.4.0",
     "inquirer": "^8.0.0"

--- a/packages/dma-contracts/tasks/ownership-tool/index.ts
+++ b/packages/dma-contracts/tasks/ownership-tool/index.ts
@@ -1,0 +1,301 @@
+import { getConfigByNetwork } from '@deploy-configurations/configs'
+import { SystemConfig } from '@deploy-configurations/types/deployment-config'
+import { Network } from '@deploy-configurations/types/network'
+import { input } from '@inquirer/prompts'
+import { OperationsRegistry, ServiceRegistry } from '@typechain/index'
+import { Signer } from 'ethers'
+import { task, types } from 'hardhat/config'
+
+import {
+  getOperationRegistry,
+  getServiceRegistry,
+  isInvalidAddress,
+  OperationRegistryMaybe,
+  ServiceRegistryMaybe,
+} from '../common'
+
+type ContractOwnership = {
+  address: string
+  owner: string
+  requiredDelay: number
+}
+
+type SystemOwnership = {
+  serviceRegistry: ContractOwnership
+  operationsRegistry: ContractOwnership
+}
+
+type System = {
+  config: SystemConfig
+  serviceRegistry: ServiceRegistry
+  operationsRegistry: OperationsRegistry
+}
+
+type PendingChange = {
+  serviceRegistry: {
+    isPending: boolean
+    waitingTimeSecs: number
+  }
+}
+
+function printOwnership(systemOwnership: SystemOwnership, network: string, title = 'OWNERSHIP') {
+  console.log(`\n====== ${title} ======`)
+  console.log(`Network: ${network}\n`)
+  console.log(`ServiceRegistry: ${systemOwnership.serviceRegistry.address}`)
+  console.log(`ServiceRegistry owner: ${systemOwnership.serviceRegistry.owner}`)
+  console.log(`ServiceRegistry required delay: ${systemOwnership.serviceRegistry.requiredDelay}`)
+
+  console.log(``)
+
+  console.log(`OperationsRegistry: ${systemOwnership.operationsRegistry.address}`)
+  console.log(`OperationsRegistry owner: ${systemOwnership.operationsRegistry.owner}`)
+  console.log(
+    `OperationsRegistry required delay: ${systemOwnership.operationsRegistry.requiredDelay}`,
+  )
+  console.log('==============================\n')
+}
+
+async function getSystem(
+  network: string,
+  ethers: any,
+  signer?: Signer,
+): Promise<System | undefined> {
+  const config: SystemConfig = getConfigByNetwork(network as Network) as SystemConfig
+
+  const serviceRegistry: ServiceRegistryMaybe = await getServiceRegistry(
+    signer ? signer : ethers.provider,
+    config,
+  )
+  if (!serviceRegistry) {
+    console.log('ServiceRegistry not deployed, cannot fetch values')
+    return undefined
+  }
+
+  const operationsRegistry: OperationRegistryMaybe = await getOperationRegistry(
+    signer ? signer : ethers.provider,
+    config,
+  )
+  if (!operationsRegistry) {
+    console.log('OperationsRegistry not deployed, cannot fetch values')
+    return undefined
+  }
+
+  return {
+    config,
+    serviceRegistry,
+    operationsRegistry,
+  }
+}
+
+async function getSystemOwnership(system: System): Promise<SystemOwnership | undefined> {
+  const serviceRegistryOwner = await system.serviceRegistry.owner()
+  const serviceRegistryRequiredDelay = await system.serviceRegistry.requiredDelay()
+
+  const operationsRegistryOwner = await system.operationsRegistry.owner()
+
+  return {
+    serviceRegistry: {
+      address: system.serviceRegistry.address,
+      owner: serviceRegistryOwner,
+      requiredDelay: serviceRegistryRequiredDelay.toNumber(),
+    },
+    operationsRegistry: {
+      address: system.operationsRegistry.address,
+      owner: operationsRegistryOwner,
+      requiredDelay: 0,
+    },
+  }
+}
+
+async function showOwners(network: string, ethers: any) {
+  const system = await getSystem(network, ethers)
+  if (!system) {
+    return
+  }
+
+  const systemOwnership = await getSystemOwnership(system)
+  if (!systemOwnership) {
+    return
+  }
+
+  printOwnership(systemOwnership, network)
+}
+
+async function getPendingChangeInfo(
+  system: System,
+  newOwnerAddress: string,
+  ethers: any,
+): Promise<PendingChange> {
+  const msgData = system.serviceRegistry.interface.encodeFunctionData('transferOwnership', [
+    newOwnerAddress,
+  ])
+  const msgHash = ethers.utils.keccak256(msgData)
+
+  const requiredDelayBN = await system.serviceRegistry.requiredDelay()
+  const executionTimestampBN = await system.serviceRegistry.lastExecuted(msgHash)
+
+  const now = (await ethers.provider.getBlock('latest')).timestamp
+
+  const requiredDelay = requiredDelayBN.toNumber()
+  const requestTimestamp = executionTimestampBN.toNumber()
+
+  const isPending = requestTimestamp != 0
+  const remainingTime = requestTimestamp + requiredDelay - now
+
+  return {
+    serviceRegistry: {
+      isPending,
+      waitingTimeSecs: remainingTime < 0 ? 0 : remainingTime,
+    },
+  }
+}
+
+async function changeOwners(newOwnerAddress: string, network: string, ethers: any) {
+  const signer = (await ethers.getSigners())[0]
+
+  if (isInvalidAddress(newOwnerAddress)) {
+    throw new Error(`Invalid address for new owner: ${newOwnerAddress}`)
+  }
+
+  const system = await getSystem(network, ethers, signer)
+  if (!system) {
+    return
+  }
+
+  const systemOwnership = await getSystemOwnership(system)
+  if (!systemOwnership) {
+    return
+  }
+
+  const isServiceRegistryChangeNeeded = systemOwnership.serviceRegistry.owner !== newOwnerAddress
+  const isOperationsRegistryChangeNeeded =
+    systemOwnership.operationsRegistry.owner !== newOwnerAddress
+
+  if (!isServiceRegistryChangeNeeded) {
+    console.log(`The new owner address is already the owner of the ServiceRegistry`)
+  }
+  if (!isOperationsRegistryChangeNeeded) {
+    console.log(`The new owner address is already the owner of the OperationsRegistry`)
+  }
+
+  if (!isServiceRegistryChangeNeeded && !isOperationsRegistryChangeNeeded) {
+    console.log('No changes needed')
+    return
+  }
+
+  console.log('\n============================')
+  console.log('====== CHANGING OWNER ======')
+  console.log('============================\n')
+
+  printOwnership(systemOwnership, network, 'CURRENT CONFIG')
+
+  console.log(`======= NEW OWNER DATA =======`)
+  console.log(`Signer address: ${signer.address}`)
+  console.log(`New owner address: ${newOwnerAddress}`)
+  console.log('==============================\n')
+
+  console.log(`!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!`)
+  console.log(`!!!!!!!!!        WARNING: THIS IS A DANGEROUS OPERATION          !!!!!!!!!`)
+  console.log(`!!!!!!!!! TAKE YOUR TIME TO VERIFY THAT THE NEW OWNER IS CORRECT !!!!!!!!!`)
+  console.log(`!!!!!!!!! OTHERWISE THE CONTRACTS OWNERSHIP WILL BE LOST FOREVER !!!!!!!!!`)
+  console.log(`!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n`)
+  const answer = await input({
+    message: `Check the config above first. You are about to change the owner to ${newOwnerAddress}'. Do you want to continue? (yes/NO)`,
+  })
+
+  if (answer === 'y' || answer === 'Y') {
+    console.log(
+      "Please write 'yes' with all the letters to confirm the operation...aborting now...",
+    )
+    return
+  } else if (answer !== 'yes') {
+    console.log('Aborting now...')
+    return
+  }
+
+  console.log(`Changing owners to new address ${newOwnerAddress}...`)
+
+  const pendingChange = await getPendingChangeInfo(system, newOwnerAddress, ethers)
+  if (
+    pendingChange.serviceRegistry.isPending &&
+    pendingChange.serviceRegistry.waitingTimeSecs > 0
+  ) {
+    console.log(
+      `There is a pending change for the ServiceRegistry. Please wait ${pendingChange.serviceRegistry.waitingTimeSecs} seconds before trying again.`,
+    )
+    return
+  }
+
+  // Push changes
+  try {
+    if (isServiceRegistryChangeNeeded) {
+      console.log(`  - Transferring ownership of the ServiceRegistry to ${newOwnerAddress}...`)
+      const tx = await system.serviceRegistry.transferOwnership(newOwnerAddress)
+      await tx.wait()
+    }
+
+    if (isOperationsRegistryChangeNeeded) {
+      console.log(`  - Transferring ownership of the OperationsRegistry to ${newOwnerAddress}...`)
+      const tx = await system.operationsRegistry.transferOwnership(newOwnerAddress)
+      await tx.wait()
+    }
+  } catch (e) {
+    if (JSON.stringify(e).includes('registry/only-owner')) {
+      console.log(
+        `\nERROR: Only the previous owner can change the ownership of the contracts...aborting now`,
+      )
+    }
+    return
+  }
+
+  console.log('')
+
+  // Verify changes
+  if (
+    !pendingChange.serviceRegistry.isPending &&
+    systemOwnership.serviceRegistry.requiredDelay > 0
+  ) {
+    console.log(
+      `* System Registry change submitted, please wait ${systemOwnership.serviceRegistry.requiredDelay} seconds before executing it again...`,
+    )
+  } else {
+    const owner = await system.serviceRegistry.owner()
+
+    if (owner === newOwnerAddress) {
+      console.log('* ServiceRegistry owner changed successfully!')
+    }
+  }
+
+  const owner = await system.operationsRegistry.owner()
+
+  if (owner === newOwnerAddress) {
+    console.log('* OperationsRegistry owner changed successfully!')
+  }
+}
+
+task(
+  'ownership-tool',
+  'Retrieves or pushes the owner address for the System and Operations registry',
+)
+  .addParam('getowners', 'Gets the owner address for the System and Operations registry', 'dummy')
+  .addOptionalParam(
+    'changeowners',
+    'Changes the owner address for the System and Operations registry. Must be called by the current owner',
+    undefined,
+    types.string,
+  )
+  .setAction(async (taskArgs, hre) => {
+    const { name: network } = hre.network
+    const { ethers } = hre
+
+    // Disable the annoying duplicated definition warning
+    ethers.utils.Logger.setLogLevel(ethers.utils.Logger.levels.ERROR)
+
+    if (taskArgs.changeowners) {
+      await changeOwners(taskArgs.changeowners, network, ethers)
+    } else if (taskArgs.getowners) {
+      await showOwners(network, ethers)
+    } else {
+      throw new Error('Either --getowners, or --changeowner must be specified')
+    }
+  })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1946,6 +1946,125 @@
   resolved "https://registry.npmjs.org/@hutson/parse-repository-url/-/parse-repository-url-3.0.2.tgz"
   integrity sha512-H9XAx3hc0BQHY6l+IFSWHDySypcXsvsuLhgYLUGywmJ5pswRVQJUHpOsobnLYp2ZUaUlKiKDrgWWhosOwAEM8Q==
 
+"@inquirer/checkbox@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@inquirer/checkbox/-/checkbox-1.4.0.tgz#9e583188be55f22ed624d2829421a3354d3d8c1a"
+  integrity sha512-7YcekwCvMTjrgjUursrH6AGZUSPw7gKPMvp0VhM3iq9mL46a7AeCfOTQTW0UPeiIfWmZK8wHyAD6wIhfDyLHpw==
+  dependencies:
+    "@inquirer/core" "^5.1.0"
+    "@inquirer/type" "^1.1.5"
+    ansi-escapes "^4.3.2"
+    chalk "^4.1.2"
+    figures "^3.2.0"
+
+"@inquirer/confirm@^2.0.14":
+  version "2.0.14"
+  resolved "https://registry.yarnpkg.com/@inquirer/confirm/-/confirm-2.0.14.tgz#b87fcdf218d0ce687bd021623e091d3a80744e9e"
+  integrity sha512-Elzo5VX5lO1q9xy8CChDtDQNVLaucufdZBAM12qdfX1L3NQ+TypnZytGmWDXHBTpBTwuhEuwxNvUw7B0HCURkw==
+  dependencies:
+    "@inquirer/core" "^5.1.0"
+    "@inquirer/type" "^1.1.5"
+    chalk "^4.1.2"
+
+"@inquirer/core@^5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@inquirer/core/-/core-5.1.0.tgz#2e3f6abf1dee93eae60cd85a5168c52400f73c9c"
+  integrity sha512-EVnific72BhMOMo8mElvrYhGFWJZ73X6j0I+fITIPTsdAz6Z9A3w3csKy+XaH87/5QAEIQHR7RSCVXvQpIqNdQ==
+  dependencies:
+    "@inquirer/type" "^1.1.5"
+    "@types/mute-stream" "^0.0.2"
+    "@types/node" "^20.8.2"
+    "@types/wrap-ansi" "^3.0.0"
+    ansi-escapes "^4.3.2"
+    chalk "^4.1.2"
+    cli-spinners "^2.9.1"
+    cli-width "^4.1.0"
+    figures "^3.2.0"
+    mute-stream "^1.0.0"
+    run-async "^3.0.0"
+    signal-exit "^4.1.0"
+    strip-ansi "^6.0.1"
+    wrap-ansi "^6.2.0"
+
+"@inquirer/editor@^1.2.12":
+  version "1.2.12"
+  resolved "https://registry.yarnpkg.com/@inquirer/editor/-/editor-1.2.12.tgz#3dfa72253e8a9d915b43f3c8dbc8df85e3c627ff"
+  integrity sha512-Y7zXQqcglPbbPkx0DPwx6HQFstJR5uex4hoQprjpdxSj8+Bf04+Og6mK/FNxoQbPvoNecegtmMGxDC+hVcMJZA==
+  dependencies:
+    "@inquirer/core" "^5.1.0"
+    "@inquirer/type" "^1.1.5"
+    chalk "^4.1.2"
+    external-editor "^3.1.0"
+
+"@inquirer/expand@^1.1.13":
+  version "1.1.13"
+  resolved "https://registry.yarnpkg.com/@inquirer/expand/-/expand-1.1.13.tgz#921d36274c0b143f7bf6cefb42f002be9cd1646f"
+  integrity sha512-/+7CGCa7iyJIpli0NtukEAjSI7+wGgjYzsByLVSSAk3U696ZlCCP6iPtsWx6d1qfmaMmCzejcjylOj6OAeu4bA==
+  dependencies:
+    "@inquirer/core" "^5.1.0"
+    "@inquirer/type" "^1.1.5"
+    chalk "^4.1.2"
+    figures "^3.2.0"
+
+"@inquirer/input@^1.2.13":
+  version "1.2.13"
+  resolved "https://registry.yarnpkg.com/@inquirer/input/-/input-1.2.13.tgz#27ee5826e2988735a78f50510c9652d2ef29e39a"
+  integrity sha512-gALuvSpZRYfqygPjlYWodMZ4TXwALvw7Pk4tRFhE1oMN79rLVlg88Z/X6JCUh+uV2qLaxxgbeP+cgPWTvuWsCg==
+  dependencies:
+    "@inquirer/core" "^5.1.0"
+    "@inquirer/type" "^1.1.5"
+    chalk "^4.1.2"
+
+"@inquirer/password@^1.1.13":
+  version "1.1.13"
+  resolved "https://registry.yarnpkg.com/@inquirer/password/-/password-1.1.13.tgz#b7f0a0f7feed90e01630a9df4a14eab09697fcd6"
+  integrity sha512-6STGbL4Vm6ohE2yDBOSENCpCeywnvPux5psZVpvblGDop1oPiZkdsVI+NhsA0c4BE6YT0fNVK8Oqxf5Dgt5k7g==
+  dependencies:
+    "@inquirer/input" "^1.2.13"
+    "@inquirer/type" "^1.1.5"
+    ansi-escapes "^4.3.2"
+    chalk "^4.1.2"
+
+"@inquirer/prompts@^3.2.0":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@inquirer/prompts/-/prompts-3.2.0.tgz#8f4feaa81560d22e77b55c676e9296a108daf5b1"
+  integrity sha512-sfT7eDoveChXr8iIfwUYkoVBjUcKqXluhjM0EVhRhN59ZuJCc5DAdnuKwaFXomwESDoN0f+2zHy+MpxUg+EZuQ==
+  dependencies:
+    "@inquirer/checkbox" "^1.4.0"
+    "@inquirer/confirm" "^2.0.14"
+    "@inquirer/core" "^5.1.0"
+    "@inquirer/editor" "^1.2.12"
+    "@inquirer/expand" "^1.1.13"
+    "@inquirer/input" "^1.2.13"
+    "@inquirer/password" "^1.1.13"
+    "@inquirer/rawlist" "^1.2.13"
+    "@inquirer/select" "^1.3.0"
+
+"@inquirer/rawlist@^1.2.13":
+  version "1.2.13"
+  resolved "https://registry.yarnpkg.com/@inquirer/rawlist/-/rawlist-1.2.13.tgz#e74f003d417add415fea8c349d186eef7cda5032"
+  integrity sha512-f+bASrCY2x2F90MrBYX7nUSetL6FsVLfskhGWEyVwj6VIXzc9T878z3v7KU3V10D1trWrCVHOdeqEcbnO68yhg==
+  dependencies:
+    "@inquirer/core" "^5.1.0"
+    "@inquirer/type" "^1.1.5"
+    chalk "^4.1.2"
+
+"@inquirer/select@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@inquirer/select/-/select-1.3.0.tgz#00dfa5068bea85bffeb7aa7c402407bb590c8cd4"
+  integrity sha512-3sL5odCDYI+i+piAFqFa5ULDUKEpc0U1zEY4Wm6gjP6nMAHWM8r1UzMlpQXCyHny91Tz+oeSLeKinAde0z6R7w==
+  dependencies:
+    "@inquirer/core" "^5.1.0"
+    "@inquirer/type" "^1.1.5"
+    ansi-escapes "^4.3.2"
+    chalk "^4.1.2"
+    figures "^3.2.0"
+
+"@inquirer/type@^1.1.5":
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/@inquirer/type/-/type-1.1.5.tgz#b8c171f755859c8159b10e41e1e3a88f0ca99d7f"
+  integrity sha512-wmwHvHozpPo4IZkkNtbYenem/0wnfI6hvOcGKmPEa0DwuaH5XUQzFqy6OpEpjEegZMhYIk8HDYITI16BPLtrRA==
+
 "@isaacs/string-locale-compare@^1.1.0":
   version "1.1.0"
   resolved "https://registry.npmjs.org/@isaacs/string-locale-compare/-/string-locale-compare-1.1.0.tgz"
@@ -4203,6 +4322,13 @@
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-9.1.1.tgz#e7c4f1001eefa4b8afbd1eee27a237fee3bf29c4"
   integrity sha512-Z61JK7DKDtdKTWwLeElSEBcWGRLY8g95ic5FoQqI9CMx0ns/Ghep3B4DfcEimiKMvtamNVULVNKEsiwV3aQmXw==
 
+"@types/mute-stream@^0.0.2":
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/@types/mute-stream/-/mute-stream-0.0.2.tgz#5a011b17307364e48591ac6829a8e40e1c10c6b0"
+  integrity sha512-FpiGjk6+IOrN0lZEfUUjdra1csU1VxwYFj4S0Zj+TJpu5x5mZW30RkEZojTadrNZHNmpCHgoE62IQZAH0OeuIA==
+  dependencies:
+    "@types/node" "*"
+
 "@types/node-fetch@^2.5.5":
   version "2.6.3"
   resolved "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.3.tgz"
@@ -4235,6 +4361,13 @@
   version "20.4.1"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-20.4.1.tgz#a6033a8718653c50ac4962977e14d0f984d9527d"
   integrity sha512-JIzsAvJeA/5iY6Y/OxZbv1lUcc8dNSE77lb2gnBH+/PJ3lFR1Ccvgwl5JWnHAkNHcRsT0TbpVOsiMKZ1F/yyJg==
+
+"@types/node@^20.8.2":
+  version "20.8.8"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.8.8.tgz#adee050b422061ad5255fc38ff71b2bb96ea2a0e"
+  integrity sha512-YRsdVxq6OaLfmR9Hy816IMp33xOBjfyOgUd77ehqg96CFywxAPbDbXvAsuN2KVg2HOT8Eh6uAfU+l4WffwPVrQ==
+  dependencies:
+    undici-types "~5.25.1"
 
 "@types/node@^8.0.0":
   version "8.10.66"
@@ -4336,6 +4469,11 @@
   version "8.1.2"
   resolved "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.2.tgz"
   integrity sha512-9GcLXF0/v3t80caGs5p2rRfkB+a8VBGLJZVih6CNFkx8IZ994wiKKLSRs9nuFwk1HevWs/1mnUmkApGrSGsShA==
+
+"@types/wrap-ansi@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/wrap-ansi/-/wrap-ansi-3.0.0.tgz#18b97a972f94f60a679fd5c796d96421b9abb9fd"
+  integrity sha512-ltIpx+kM7g/MLRZfkbL7EsCEjfzCcScLpkg37eXEtx5kmrAKBkTJwd1GIAjDSL8wTpM6Hzn5YO4pSb91BEwu1g==
 
 "@typescript-eslint/eslint-plugin@^5.27.1":
   version "5.59.1"
@@ -4815,7 +4953,7 @@ ansi-colors@^4.1.0, ansi-colors@^4.1.1:
   resolved "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz"
   integrity sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==
 
-ansi-escapes@^4.2.1, ansi-escapes@^4.3.0:
+ansi-escapes@^4.2.1, ansi-escapes@^4.3.0, ansi-escapes@^4.3.2:
   version "4.3.2"
   resolved "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz"
   integrity sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==
@@ -6532,6 +6670,11 @@ cli-spinners@^2.5.0:
   resolved "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.8.0.tgz"
   integrity sha512-/eG5sJcvEIwxcdYM86k5tPwn0MUzkX5YY3eImTGpJOZgVe4SdTMY14vQpcxgBzJ0wXwAYrS8E+c3uHeK4JNyzQ==
 
+cli-spinners@^2.9.1:
+  version "2.9.1"
+  resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-2.9.1.tgz#9c0b9dad69a6d47cbb4333c14319b060ed395a35"
+  integrity sha512-jHgecW0pxkonBJdrKsqxgRX9AcG+u/5k0Q7WPDfi8AogLAdwxEkyYYNWwZ5GvVFoFx2uiY1eNcSK00fh+1+FyQ==
+
 cli-table3@^0.5.0:
   version "0.5.1"
   resolved "https://registry.npmjs.org/cli-table3/-/cli-table3-0.5.1.tgz"
@@ -6555,6 +6698,11 @@ cli-width@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz"
   integrity sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==
+
+cli-width@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-4.1.0.tgz#42daac41d3c254ef38ad8ac037672130173691c5"
+  integrity sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==
 
 cliui@^3.2.0:
   version "3.2.0"
@@ -8900,7 +9048,7 @@ extend@^3.0.2, extend@~3.0.2:
   resolved "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz"
   integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
 
-external-editor@^3.0.3:
+external-editor@^3.0.3, external-editor@^3.1.0:
   version "3.1.0"
   resolved "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz"
   integrity sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==
@@ -9006,7 +9154,7 @@ fetch-ponyfill@^4.0.0:
   dependencies:
     node-fetch "~1.7.1"
 
-figures@3.2.0, figures@^3.0.0:
+figures@3.2.0, figures@^3.0.0, figures@^3.2.0:
   version "3.2.0"
   resolved "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz"
   integrity sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==
@@ -12959,6 +13107,11 @@ mute-stream@0.0.8, mute-stream@~0.0.4:
   resolved "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz"
   integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
 
+mute-stream@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-1.0.0.tgz#e31bd9fe62f0aed23520aa4324ea6671531e013e"
+  integrity sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==
+
 nano-json-stream-parser@^0.1.2:
   version "0.1.2"
   resolved "https://registry.npmjs.org/nano-json-stream-parser/-/nano-json-stream-parser-0.1.2.tgz"
@@ -15249,6 +15402,11 @@ run-async@^2.4.0:
   resolved "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz"
   integrity sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==
 
+run-async@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/run-async/-/run-async-3.0.0.tgz#42a432f6d76c689522058984384df28be379daad"
+  integrity sha512-540WwVDOMxA6dN6We19EcT9sc3hkXPw5mzRNGM3FkdN/vtE9NFvj5lFAPNwUDmJjXidm3v7TC1cTE7t17Ulm1Q==
+
 run-parallel-limit@^1.1.0:
   version "1.1.0"
   resolved "https://registry.npmjs.org/run-parallel-limit/-/run-parallel-limit-1.1.0.tgz"
@@ -15597,6 +15755,11 @@ signal-exit@^4.0.1:
   version "4.0.1"
   resolved "https://registry.npmjs.org/signal-exit/-/signal-exit-4.0.1.tgz"
   integrity sha512-uUWsN4aOxJAS8KOuf3QMyFtgm1pkb6I+KRZbRF/ghdf5T7sM+B1lLLzPDxswUjkmHyxQAVzEgG35E3NzDM9GVw==
+
+signal-exit@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-4.1.0.tgz#952188c1cbd546070e2dd20d0f41c0ae0530cb04"
+  integrity sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==
 
 sigstore@^1.3.0:
   version "1.4.0"
@@ -17068,6 +17231,11 @@ underscore@1.9.1:
   resolved "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz"
   integrity sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg==
 
+undici-types@~5.25.1:
+  version "5.25.3"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-5.25.3.tgz#e044115914c85f0bcbb229f346ab739f064998c3"
+  integrity sha512-Ga1jfYwRn7+cP9v8auvEXN1rX3sWqlayd4HP7OKk4mZWylEmu3KzXDUGrQUN6Ol7qo1gPvB2e5gX6udnyEPgdA==
+
 undici@^5.14.0:
   version "5.22.0"
   resolved "https://registry.npmjs.org/undici/-/undici-5.22.0.tgz"
@@ -18529,7 +18697,7 @@ wrap-ansi@^5.1.0:
     string-width "^3.0.0"
     strip-ansi "^5.0.0"
 
-wrap-ansi@^6.0.1:
+wrap-ansi@^6.0.1, wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==


### PR DESCRIPTION
New tool to change the ownership of the `ServiceRegistry` and the `OperationsRegistry` when it is still not owned by the multi-sig

The documentation can be found here: https://www.notion.so/oazo/Change-Ownership-Tool-eab7cb94cf4146acb6085296503a3a4c