### PR TITLE
TECH-2428 - Increase swap size

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -17,6 +17,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
+      - name: Set Swap Space
+        uses: pierotofy/set-swap-space@master
+        with:
+          swap-size-gb: 10
+
       - name: Check out github repository
         id: github-checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
The default swap size is 4GB, so this will add 6GB to it. Given that the disk space available is 14GB, there should be enough left after this. If at any point this action fails due to the disk being full, just lower the swap's size.