### PR TITLE
🐛 fix(flashloan sim): override flashloan amount for Spark with Balancer

### DIFF
--- a/packages/dma-library/src/strategies/aave-like/multiply/common/build-flashloan-sim-args.ts
+++ b/packages/dma-library/src/strategies/aave-like/multiply/common/build-flashloan-sim-args.ts
@@ -1,4 +1,4 @@
-import { FEE_BASE, ONE, ZERO } from '@dma-common/constants'
+import { FEE_BASE } from '@dma-common/constants'
 import * as StrategyParams from '@dma-library/types/strategy-params'
 import { WithFlashLoanArgs } from '@dma-library/types/strategy-params'
 import { isAaveLikeProtocol } from '@dma-library/utils/aave-like'
@@ -16,12 +16,7 @@ export function buildFlashloanSimArgs(
 ): IPositionTransitionParams['flashloan'] | undefined {
   const lendingProtocol = dependencies.protocolType
   if (isAaveLikeProtocol(lendingProtocol)) {
-    const ltv = new BigNumber(reserveDataForFlashloan.ltv.toString())
-    const fallbackMaxLTV = ONE
-    const maxLoanToValueForFL = ltv.eq(ZERO)
-      ? fallbackMaxLTV
-      : new BigNumber(reserveDataForFlashloan.ltv.toString()).div(FEE_BASE)
-
+    const maxLoanToValueForFL = new BigNumber(reserveDataForFlashloan.ltv.toString()).div(FEE_BASE)
     return {
       maxLoanToValueFL: maxLoanToValueForFL,
       token: {

--- a/packages/dma-library/src/strategies/aave-like/multiply/common/build-flashloan-sim-args.ts
+++ b/packages/dma-library/src/strategies/aave-like/multiply/common/build-flashloan-sim-args.ts
@@ -1,4 +1,4 @@
-import { FEE_BASE } from '@dma-common/constants'
+import { FEE_BASE, ONE, ZERO } from '@dma-common/constants'
 import * as StrategyParams from '@dma-library/types/strategy-params'
 import { WithFlashLoanArgs } from '@dma-library/types/strategy-params'
 import { isAaveLikeProtocol } from '@dma-library/utils/aave-like'
@@ -16,7 +16,11 @@ export function buildFlashloanSimArgs(
 ): IPositionTransitionParams['flashloan'] | undefined {
   const lendingProtocol = dependencies.protocolType
   if (isAaveLikeProtocol(lendingProtocol)) {
-    const maxLoanToValueForFL = new BigNumber(reserveDataForFlashloan.ltv.toString()).div(FEE_BASE)
+    const ltv = new BigNumber(reserveDataForFlashloan.ltv.toString())
+    const fallbackMaxLTV = ONE
+    const maxLoanToValueForFL = ltv.eq(ZERO)
+      ? fallbackMaxLTV
+      : new BigNumber(reserveDataForFlashloan.ltv.toString()).div(FEE_BASE)
 
     return {
       maxLoanToValueFL: maxLoanToValueForFL,

--- a/packages/dma-library/src/strategies/aave-like/multiply/open/simulate.ts
+++ b/packages/dma-library/src/strategies/aave-like/multiply/open/simulate.ts
@@ -49,6 +49,7 @@ export async function simulate(
    * Left in a position that make it difficult to re-open it
    */
   const currentPosition = await resolveCurrentPositionForProtocol(args, dependencies)
+
   const protocolData = await resolveProtocolData(
     {
       collateralTokenAddress,

--- a/packages/dma-library/src/strategies/aave/common/get-flashloan-token.ts
+++ b/packages/dma-library/src/strategies/aave/common/get-flashloan-token.ts
@@ -20,22 +20,10 @@ export function getFlashloanToken({
   debt,
 }: FlashloanDependencies): WithFlashLoanArgs {
   if (protocol === 'Spark') {
-    if (debt.symbol !== 'DAI') {
-      return {
-        flashloan: {
-          token: debt,
-        },
-      }
-    } else {
-      return {
-        flashloan: {
-          token: {
-            symbol: 'WETH' as const,
-            address: addresses.tokens.WETH,
-            precision: 18,
-          },
-        },
-      }
+    return {
+      flashloan: {
+        token: debt,
+      },
     }
   }
 

--- a/packages/dma-library/src/strategies/aave/common/get-flashloan-token.ts
+++ b/packages/dma-library/src/strategies/aave/common/get-flashloan-token.ts
@@ -20,10 +20,22 @@ export function getFlashloanToken({
   debt,
 }: FlashloanDependencies): WithFlashLoanArgs {
   if (protocol === 'Spark') {
-    return {
-      flashloan: {
-        token: debt,
-      },
+    if (debt.symbol !== 'DAI') {
+      return {
+        flashloan: {
+          token: debt,
+        },
+      }
+    } else {
+      return {
+        flashloan: {
+          token: {
+            symbol: 'WETH' as const,
+            address: addresses.tokens.WETH,
+            precision: 18,
+          },
+        },
+      }
     }
   }
 

--- a/packages/domain/src/position.ts
+++ b/packages/domain/src/position.ts
@@ -311,7 +311,7 @@ export class Position implements IPosition {
           simulatedAdjust.delta.debt.minus(mappedParams.depositedByUser?.debtInWei || ZERO),
           mappedParams.flashloan.token.precision,
           this.debt.precision,
-          mappedParams.flashloan.maxLoanToValueFL,
+          mappedParams.flashloan.maxLoanToValueFL || ONE,
         )
       : ZERO
 


### PR DESCRIPTION
**Changes**

Return the correct flashloan amount in the simulation for Spark w/ Balancer

