### PR TITLE
Bump version because it was build wrong

### DIFF
--- a/packages/dma-library/package.json
+++ b/packages/dma-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oasisdex/dma-library",
-  "version": "0.5.20",
+  "version": "0.5.21",
   "typings": "lib/index.d.ts",
   "types": "lib/index.d.ts",
   "main": "lib/index.js",


### PR DESCRIPTION
0.5.20 was build in a bad way, please use this one.