### PR TITLE
Handle empty pools while calc lup

### DIFF
--- a/packages/dma-library/package.json
+++ b/packages/dma-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oasisdex/dma-library",
-  "version": "0.5.22",
+  "version": "0.5.23",
   "typings": "lib/index.d.ts",
   "types": "lib/index.d.ts",
   "main": "lib/index.js",

--- a/packages/dma-library/src/protocols/ajna/utils.ts
+++ b/packages/dma-library/src/protocols/ajna/utils.ts
@@ -290,6 +290,11 @@ export function calculateMaxGenerate(
 
 export function calculateNewLup(pool: AjnaPool, debtChange: BigNumber): [BigNumber, BigNumber] {
   const sortedBuckets = [...pool.buckets].sort((a, b) => a.index.minus(b.index).toNumber())
+
+  if (sortedBuckets.length === 0) {
+    return [pool.lowestUtilizedPrice, pool.lowestUtilizedPriceIndex]
+  }
+
   const totalPoolLiquidity = getTotalPoolLiquidity(pool.buckets)
 
   let remainingDebt = pool.debt.plus(debtChange)

--- a/packages/dma-library/src/protocols/ajna/utils.ts
+++ b/packages/dma-library/src/protocols/ajna/utils.ts
@@ -289,12 +289,11 @@ export function calculateMaxGenerate(
 }
 
 export function calculateNewLup(pool: AjnaPool, debtChange: BigNumber): [BigNumber, BigNumber] {
-  const sortedBuckets = [...pool.buckets].sort((a, b) => a.index.minus(b.index).toNumber())
-
-  if (sortedBuckets.length === 0) {
+  if (pool.buckets.length === 0) {
     return [pool.lowestUtilizedPrice, pool.lowestUtilizedPriceIndex]
   }
 
+  const sortedBuckets = [...pool.buckets].sort((a, b) => a.index.minus(b.index).toNumber())
   const totalPoolLiquidity = getTotalPoolLiquidity(pool.buckets)
 
   let remainingDebt = pool.debt.plus(debtChange)


### PR DESCRIPTION
## [Handle empty pools while calc lup](https://app.shortcut.com/oazo-apps/story/13172/bug-goerli-borrow-pools-with-no-liquidity-borrow-input-field-is-not-validated-and-confirm-button-is-enabled)

Please provide a link to the ticket:

## Description of Changes

Please list the changes introduced by this PR:

- added condition in method responsible for calculating new pool to take into account empty pools

## How to Test

Please provide instructions on how to test the changes in this PR:

- it will be tested on UI

## PR Definition of Done

Please ensure the following requirements have been met before marking the PR as ready for review:

- [ ] All checks are passing
- [ ] PR is linked to a corresponding ticket
- [ ] PR title is clear and concise
- [ ] Code has been self-reviewed and any fixes or improvements noted (See Code review standards in Notion)
- [ ] Documentation has been updated if necessary
