### PR TITLE
Adjust neutral price simulation

### DIFF
--- a/packages/dma-library/package.json
+++ b/packages/dma-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oasisdex/dma-library",
-  "version": "0.5.24",
+  "version": "0.5.25",
   "typings": "lib/index.d.ts",
   "types": "lib/index.d.ts",
   "main": "lib/index.js",

--- a/packages/dma-library/src/protocols/ajna/utils.ts
+++ b/packages/dma-library/src/protocols/ajna/utils.ts
@@ -1,4 +1,4 @@
-import { ZERO } from '@dma-common/constants'
+import { ONE, ZERO } from '@dma-common/constants'
 import { negativeToZero } from '@dma-common/utils/common'
 import { ajnaCollateralizationFactor } from '@dma-library/protocols/ajna/consts'
 import { ajnaBuckets } from '@dma-library/strategies'
@@ -491,14 +491,9 @@ export function getNeutralPrice(
   positionCollateral: BigNumber,
   interestRate: BigNumber,
 ) {
-  const thresholdPrice =
-    positionCollateral.isZero() || positionDebt.isZero()
-      ? ZERO
-      : positionDebt.div(positionCollateral)
+  const npToTpRatio = ONE.plus(interestRate.sqrt().div(2))
 
-  return thresholdPrice.times(
-    new BigNumber(ajnaCollateralizationFactor).plus(interestRate.sqrt().div(2)),
-  )
+  return positionDebt.times(npToTpRatio).div(positionCollateral)
 }
 
 export function getAjnaEarnDepositFee({


### PR DESCRIPTION
## [Adjust neutral price simulation](https://app.shortcut.com/oazo-apps/story/13251/bug-goerli-borrow-liquidation-price-in-simulation-does-not-match-with-final-value)

Please provide a link to the ticket:

## Description of Changes

Please list the changes introduced by this PR:

- adjusted neutral price simulation

## How to Test

Please provide instructions on how to test the changes in this PR:

## PR Definition of Done

Please ensure the following requirements have been met before marking the PR as ready for review:

- [ ] All checks are passing
- [ ] PR is linked to a corresponding ticket
- [ ] PR title is clear and concise
- [ ] Code has been self-reviewed and any fixes or improvements noted (See Code review standards in Notion)
- [ ] Documentation has been updated if necessary
