### PR TITLE
Adjusted withdraw close to max ltv warning while doing payback

### DIFF
--- a/packages/dma-library/package.json
+++ b/packages/dma-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oasisdex/dma-library",
-  "version": "0.5.27",
+  "version": "0.5.28",
   "typings": "lib/index.d.ts",
   "types": "lib/index.d.ts",
   "main": "lib/index.js",

--- a/packages/dma-library/src/strategies/ajna/validation/borrowish/closeToMaxLtv.ts
+++ b/packages/dma-library/src/strategies/ajna/validation/borrowish/closeToMaxLtv.ts
@@ -27,7 +27,10 @@ export function validateWithdrawCloseToMaxLtv(
   position: AjnaPosition,
   positionBefore: AjnaPosition,
 ): AjnaWarning[] {
-  if (position.maxRiskRatio.loanToValue.minus(MAX_LTV_OFFSET).lte(position.riskRatio.loanToValue)) {
+  if (
+    position.maxRiskRatio.loanToValue.minus(MAX_LTV_OFFSET).lte(position.riskRatio.loanToValue) &&
+    !positionBefore.collateralAmount.eq(position.collateralAmount)
+  ) {
     return [
       {
         name: 'withdraw-close-to-max-ltv',


### PR DESCRIPTION
## [Adjusted withdraw close to max ltv warning while doing payback](https://app.shortcut.com/oazo-apps/story/13298/bug-oracless-goerli-borrow-paying-back-debt-triggers-withdrawing-warning-message)

Please provide a link to the ticket:

## Description of Changes

Please list the changes introduced by this PR:

- adjusted withdraw close to max ltv warning logic

## How to Test

Please provide instructions on how to test the changes in this PR:

## PR Definition of Done

Please ensure the following requirements have been met before marking the PR as ready for review:

- [ ] All checks are passing
- [ ] PR is linked to a corresponding ticket
- [ ] PR title is clear and concise
- [ ] Code has been self-reviewed and any fixes or improvements noted (See Code review standards in Notion)
- [ ] Documentation has been updated if necessary
