### PR TITLE
Max generate on unutilized pool fix

### DIFF
--- a/packages/dma-library/package.json
+++ b/packages/dma-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oasisdex/dma-library",
-  "version": "0.5.29",
+  "version": "0.5.30",
   "typings": "lib/index.d.ts",
   "types": "lib/index.d.ts",
   "main": "lib/index.js",


### PR DESCRIPTION
## [Max generate on unutilized pool fix](https://app.shortcut.com/oazo-apps/story/13352/bug-base-maybe-all-the-max-amount-to-borrow-when-opening-a-borrow-position-is-greater-than-the-liquidity-in-the-pool)

Please provide a link to the ticket:

## Description of Changes

Please list the changes introduced by this PR:

- adjusted max generate calcs

## How to Test

Please provide instructions on how to test the changes in this PR:

## PR Definition of Done

Please ensure the following requirements have been met before marking the PR as ready for review:

- [ ] All checks are passing
- [ ] PR is linked to a corresponding ticket
- [ ] PR title is clear and concise
- [ ] Code has been self-reviewed and any fixes or improvements noted (See Code review standards in Notion)
- [ ] Documentation has been updated if necessary
