### PR TITLE
[aave-like] Fix currentPosition arg in adjust being ignored

### DIFF
--- a/packages/dma-library/src/strategies/aave-like/multiply/adjust/simulate.ts
+++ b/packages/dma-library/src/strategies/aave-like/multiply/adjust/simulate.ts
@@ -31,7 +31,8 @@ export async function simulate(
     dependencies.addresses,
   )
 
-  const currentPosition = dependencies.currentPosition || await resolveCurrentPositionForProtocol(args, dependencies)
+  const currentPosition =
+    dependencies.currentPosition || (await resolveCurrentPositionForProtocol(args, dependencies))
   const protocolData = await resolveProtocolData(
     {
       collateralTokenAddress,

--- a/packages/dma-library/src/strategies/aave-like/multiply/adjust/simulate.ts
+++ b/packages/dma-library/src/strategies/aave-like/multiply/adjust/simulate.ts
@@ -31,7 +31,7 @@ export async function simulate(
     dependencies.addresses,
   )
 
-  const currentPosition = await resolveCurrentPositionForProtocol(args, dependencies)
+  const currentPosition = dependencies.currentPosition || await resolveCurrentPositionForProtocol(args, dependencies)
   const protocolData = await resolveProtocolData(
     {
       collateralTokenAddress,

--- a/packages/dma-library/src/types/strategy-params.ts
+++ b/packages/dma-library/src/types/strategy-params.ts
@@ -102,7 +102,7 @@ export type WithDebtChange<Tokens> = {
 
 type SharedStrategyDependencies = {
   provider: providers.Provider
-  currentPosition: IPosition
+  currentPosition: AaveLikePosition
   proxy: Address
   user: Address
   network: Network


### PR DESCRIPTION
The AaveLike adjust strategy accepts a currentPosition parameter, but it was being ignored - causing the current position to always be fetched based on the proxy address.

This will also increase performance when the position is passed in, as it avoids calling the view function.
