### PR TITLE
Add Morpho Blue contract address on goerli

### DIFF
--- a/packages/addresses/package.json
+++ b/packages/addresses/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oasisdex/addresses",
-  "version": "0.1.24",
+  "version": "0.1.25",
   "typings": "lib/index.d.ts",
   "types": "lib/index.d.ts",
   "main": "lib/index.js",

--- a/packages/deploy-configurations/configs/arbitrum.conf.ts
+++ b/packages/deploy-configurations/configs/arbitrum.conf.ts
@@ -796,7 +796,7 @@ export const config: SystemConfig = {
   morphoblue: {
     MorphoBlue: {
       name: 'MorphoBlue',
-      address: '0x0000000000000000000000000000000000000000',
+      address: ADDRESS_ZERO,
       serviceRegistryName: SERVICE_REGISTRY_NAMES.morphoblue.MORPHO_BLUE,
     },
   },

--- a/packages/deploy-configurations/configs/base.conf.ts
+++ b/packages/deploy-configurations/configs/base.conf.ts
@@ -1,4 +1,4 @@
-import { loadContractNames } from '@deploy-configurations/constants'
+import { ADDRESS_ZERO, loadContractNames } from '@deploy-configurations/constants'
 import { SystemConfig } from '@deploy-configurations/types/deployment-config'
 import { Network } from '@deploy-configurations/types/network'
 
@@ -1238,7 +1238,7 @@ export const config: SystemConfig = {
   morphoblue: {
     MorphoBlue: {
       name: 'MorphoBlue',
-      address: '0x0000000000000000000000000000000000000000',
+      address: ADDRESS_ZERO,
       serviceRegistryName: SERVICE_REGISTRY_NAMES.morphoblue.MORPHO_BLUE,
     },
   },

--- a/packages/deploy-configurations/configs/goerli.conf.ts
+++ b/packages/deploy-configurations/configs/goerli.conf.ts
@@ -1120,7 +1120,7 @@ export const config: SystemConfig = {
   morphoblue: {
     MorphoBlue: {
       name: 'MorphoBlue',
-      address: '0x0000000000000000000000000000000000000000',
+      address: '0x64c7044050Ba0431252df24fEd4d9635a275CB41',
       serviceRegistryName: SERVICE_REGISTRY_NAMES.morphoblue.MORPHO_BLUE,
     },
   },

--- a/packages/deploy-configurations/configs/hardhat.conf.ts
+++ b/packages/deploy-configurations/configs/hardhat.conf.ts
@@ -1326,7 +1326,7 @@ export const config: SystemConfig = {
   morphoblue: {
     MorphoBlue: {
       name: 'MorphoBlue',
-      address: '0x0000000000000000000000000000000000000000',
+      address: ADDRESS_ZERO,
       serviceRegistryName: SERVICE_REGISTRY_NAMES.morphoblue.MORPHO_BLUE,
     },
   },

--- a/packages/deploy-configurations/configs/local.conf.ts
+++ b/packages/deploy-configurations/configs/local.conf.ts
@@ -1279,7 +1279,7 @@ export const config: SystemConfig = {
   morphoblue: {
     MorphoBlue: {
       name: 'MorphoBlue',
-      address: '0x0000000000000000000000000000000000000000',
+      address: ADDRESS_ZERO,
       serviceRegistryName: SERVICE_REGISTRY_NAMES.morphoblue.MORPHO_BLUE,
     },
   },

--- a/packages/deploy-configurations/configs/mainnet.conf.ts
+++ b/packages/deploy-configurations/configs/mainnet.conf.ts
@@ -1352,7 +1352,7 @@ export const config: SystemConfig = {
   morphoblue: {
     MorphoBlue: {
       name: 'MorphoBlue',
-      address: '0x0000000000000000000000000000000000000000',
+      address: ADDRESS_ZERO,
       serviceRegistryName: SERVICE_REGISTRY_NAMES.morphoblue.MORPHO_BLUE,
     },
   },

--- a/packages/deploy-configurations/configs/optimism.conf.ts
+++ b/packages/deploy-configurations/configs/optimism.conf.ts
@@ -1103,7 +1103,7 @@ export const config: SystemConfig = {
   morphoblue: {
     MorphoBlue: {
       name: 'MorphoBlue',
-      address: '0x0000000000000000000000000000000000000000',
+      address: ADDRESS_ZERO,
       serviceRegistryName: SERVICE_REGISTRY_NAMES.morphoblue.MORPHO_BLUE,
     },
   },

--- a/packages/deploy-configurations/configs/sepolia.conf.ts
+++ b/packages/deploy-configurations/configs/sepolia.conf.ts
@@ -1120,7 +1120,7 @@ export const config: SystemConfig = {
   morphoblue: {
     MorphoBlue: {
       name: 'MorphoBlue',
-      address: '0x0000000000000000000000000000000000000000',
+      address: ADDRESS_ZERO,
       serviceRegistryName: SERVICE_REGISTRY_NAMES.morphoblue.MORPHO_BLUE,
     },
   },

--- a/packages/deploy-configurations/configs/tenderly.conf.ts
+++ b/packages/deploy-configurations/configs/tenderly.conf.ts
@@ -1328,7 +1328,7 @@ export const config: SystemConfig = {
   morphoblue: {
     MorphoBlue: {
       name: 'MorphoBlue',
-      address: '0x0000000000000000000000000000000000000000',
+      address: ADDRESS_ZERO,
       serviceRegistryName: SERVICE_REGISTRY_NAMES.morphoblue.MORPHO_BLUE,
     },
   },

--- a/packages/deploy-configurations/configs/test/arbitrum.conf.ts
+++ b/packages/deploy-configurations/configs/test/arbitrum.conf.ts
@@ -793,7 +793,7 @@ export const config: SystemConfig = {
   morphoblue: {
     MorphoBlue: {
       name: 'MorphoBlue',
-      address: '0x0000000000000000000000000000000000000000',
+      address: ADDRESS_ZERO,
       serviceRegistryName: SERVICE_REGISTRY_NAMES.morphoblue.MORPHO_BLUE,
     },
   },

--- a/packages/deploy-configurations/configs/test/mainnet.conf.ts
+++ b/packages/deploy-configurations/configs/test/mainnet.conf.ts
@@ -1137,7 +1137,7 @@ export const config: SystemConfig = {
   morphoblue: {
     MorphoBlue: {
       name: 'MorphoBlue',
-      address: '0x0000000000000000000000000000000000000000',
+      address: ADDRESS_ZERO,
       serviceRegistryName: SERVICE_REGISTRY_NAMES.morphoblue.MORPHO_BLUE,
     },
   },

--- a/packages/deploy-configurations/configs/test/optimism.conf.ts
+++ b/packages/deploy-configurations/configs/test/optimism.conf.ts
@@ -1088,7 +1088,7 @@ export const config: SystemConfig = {
   morphoblue: {
     MorphoBlue: {
       name: 'MorphoBlue',
-      address: '0x0000000000000000000000000000000000000000',
+      address: ADDRESS_ZERO,
       serviceRegistryName: SERVICE_REGISTRY_NAMES.morphoblue.MORPHO_BLUE,
     },
   },


### PR DESCRIPTION
## Add Morpho Blue contract address on goerli

## Description of Changes

- Added Morpho Blue Goerli contract address,
- replaced `0x0000000000000000000000000000000000000000` with `ADDRESS_ZERO` const.