### PR TITLE
Fix liquidation price when multiply

### DIFF
--- a/packages/dma-library/src/strategies/ajna/multiply/common.ts
+++ b/packages/dma-library/src/strategies/ajna/multiply/common.ts
@@ -4,7 +4,11 @@ import { areAddressesEqual } from '@dma-common/utils/addresses/index'
 import { amountFromWei, amountToWei } from '@dma-common/utils/common'
 import { calculateFee } from '@dma-common/utils/swap'
 import { BALANCER_FEE } from '@dma-library/config/flashloan-fees'
-import { prepareAjnaDMAPayload, resolveAjnaEthAction } from '@dma-library/protocols/ajna'
+import {
+  getNeutralPrice,
+  prepareAjnaDMAPayload,
+  resolveAjnaEthAction,
+} from '@dma-library/protocols/ajna'
 import {
   validateBorrowUndercollateralized,
   validateLiquidity,
@@ -193,7 +197,7 @@ export function prepareAjnaMultiplyDMAPayload(
     debtAmount,
     args.collateralPrice,
     args.quotePrice,
-    args.position.t0NeutralPrice,
+    getNeutralPrice(debtAmount, collateralAmount, args.position.pool.interestRate),
     args.position.pnl,
   )
 


### PR DESCRIPTION
## [Fix liquidation price when multiply](https://app.shortcut.com/oazo-apps/story/13697/liquidation-price-not-changing-when-simulating-adjusting-multiply-position)

Please provide a link to the ticket:

## Description of Changes

Please list the changes introduced by this PR:

- passed correct calcs for t0neutral price

## How to Test

Please provide instructions on how to test the changes in this PR:

## PR Definition of Done

Please ensure the following requirements have been met before marking the PR as ready for review:

- [ ] All checks are passing
- [ ] PR is linked to a corresponding ticket
- [ ] PR title is clear and concise
- [ ] Code has been self-reviewed and any fixes or improvements noted (See Code review standards in Notion)
- [ ] Documentation has been updated if necessary
