### PR TITLE
Update DMA to 0.6.0

### DIFF
--- a/packages/dma-library/package.json
+++ b/packages/dma-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oasisdex/dma-library",
-  "version": "0.5.39",
+  "version": "0.6.0",
   "typings": "lib/index.d.ts",
   "types": "lib/index.d.ts",
   "main": "lib/index.js",


### PR DESCRIPTION
## Update DMA to 0.6.0

Updating package version so I can release new version with Morpho Blue views and strategies.
As this will add entire Morpho Blue support, it's a minor release, not patch like usual. 