### PR TITLE
Add quotePrecission to validateLiquidity method

### DIFF
--- a/packages/dma-library/package.json
+++ b/packages/dma-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oasisdex/dma-library",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "typings": "lib/index.d.ts",
   "types": "lib/index.d.ts",
   "main": "lib/index.js",

--- a/packages/dma-library/src/strategies/morphoblue/borrow/deposit-borrow.ts
+++ b/packages/dma-library/src/strategies/morphoblue/borrow/deposit-borrow.ts
@@ -104,8 +104,13 @@ export const depositBorrow: MorphoDepositBorrowStrategy = async (args, dependenc
   const warnings = [...validateGenerateCloseToMaxLtv(targetPosition, position)]
 
   const errors = [
-    ...validateLiquidity(position, args.quoteAmount),
-    ...validateBorrowUndercollateralized(targetPosition, position, args.quoteAmount),
+    ...validateLiquidity(position, args.quoteAmount, args.quotePrecision),
+    ...validateBorrowUndercollateralized(
+      targetPosition,
+      position,
+      args.quoteAmount,
+      args.quotePrecision,
+    ),
   ]
 
   return {

--- a/packages/dma-library/src/strategies/morphoblue/borrow/open.ts
+++ b/packages/dma-library/src/strategies/morphoblue/borrow/open.ts
@@ -113,8 +113,13 @@ export const open: MorphoOpenBorrowStrategy = async (args, dependencies) => {
   const warnings = [...validateGenerateCloseToMaxLtv(targetPosition, position)]
 
   const errors = [
-    ...validateLiquidity(position, args.quoteAmount),
-    ...validateBorrowUndercollateralized(targetPosition, position, args.quoteAmount),
+    ...validateLiquidity(position, args.quoteAmount, args.quotePrecision),
+    ...validateBorrowUndercollateralized(
+      targetPosition,
+      position,
+      args.quoteAmount,
+      args.quotePrecision,
+    ),
   ]
 
   return {

--- a/packages/dma-library/src/strategies/morphoblue/borrow/payback-withdraw.ts
+++ b/packages/dma-library/src/strategies/morphoblue/borrow/payback-withdraw.ts
@@ -93,7 +93,7 @@ export const paybackWithdraw: MorphoPaybackWithdrawStrategy = async (args, depen
   const warnings = [...validateWithdrawCloseToMaxLtv(targetPosition, position)]
 
   const errors = [
-    ...validateBorrowUndercollateralized(targetPosition, position, ZERO),
+    ...validateBorrowUndercollateralized(targetPosition, position, ZERO, args.quotePrecision),
     ...validateOverRepay(position, args.quoteAmount),
   ]
 

--- a/packages/dma-library/src/strategies/morphoblue/validation/validateBorrowUndercollateralized.ts
+++ b/packages/dma-library/src/strategies/morphoblue/validation/validateBorrowUndercollateralized.ts
@@ -7,8 +7,9 @@ export function validateBorrowUndercollateralized(
   position: MorphoBluePosition,
   targetPosition: MorphoBluePosition,
   borrowAmount: BigNumber,
+  quotePrecision: number,
 ): AjnaError[] {
-  if (validateLiquidity(position, borrowAmount).length > 0) {
+  if (validateLiquidity(position, borrowAmount, quotePrecision).length > 0) {
     return []
   }
 

--- a/packages/dma-library/src/strategies/morphoblue/validation/validateLiquidity.ts
+++ b/packages/dma-library/src/strategies/morphoblue/validation/validateLiquidity.ts
@@ -1,11 +1,16 @@
+import { amountFromWei } from '@dma-common/utils/common'
 import { AjnaError, MorphoBluePosition } from '@dma-library/types'
 import { BigNumber } from 'bignumber.js'
 
 export function validateLiquidity(
   position: MorphoBluePosition,
   borrowAmount: BigNumber,
+  quotePrecision: number,
 ): AjnaError[] {
-  if (position.market.totalSupplyAssets.minus(position.market.totalBorrowAssets).lt(borrowAmount)) {
+  const totalSupplyAssets = amountFromWei(position.market.totalSupplyAssets, quotePrecision)
+  const totalBorrowAssets = amountFromWei(position.market.totalBorrowAssets, quotePrecision)
+
+  if (totalSupplyAssets.minus(totalBorrowAssets).lt(borrowAmount)) {
     return [
       {
         name: 'not-enough-liquidity',


### PR DESCRIPTION
## [Add quotePrecission to validateLiquidity method](https://app.shortcut.com/oazo-apps/story/13864/library-incorrectly-says-that-there-is-not-enough-liquidity-for-wsteth-usdc-market)

## Description of Changes

Please list the changes introduced by this PR:

- Added required `quotePrecision` param to `validateLiquidity` method.
- Changed calculations of `totalSupplyAssets` and `totalBorrowAssets`.