### PR TITLE
Fix totalSupplyAssets and totalBorrowAssets

### DIFF
--- a/packages/dma-library/package.json
+++ b/packages/dma-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oasisdex/dma-library",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "typings": "lib/index.d.ts",
   "types": "lib/index.d.ts",
   "main": "lib/index.js",

--- a/packages/dma-library/src/strategies/morphoblue/borrow/deposit-borrow.ts
+++ b/packages/dma-library/src/strategies/morphoblue/borrow/deposit-borrow.ts
@@ -104,13 +104,8 @@ export const depositBorrow: MorphoDepositBorrowStrategy = async (args, dependenc
   const warnings = [...validateGenerateCloseToMaxLtv(targetPosition, position)]
 
   const errors = [
-    ...validateLiquidity(position, args.quoteAmount, args.quotePrecision),
-    ...validateBorrowUndercollateralized(
-      targetPosition,
-      position,
-      args.quoteAmount,
-      args.quotePrecision,
-    ),
+    ...validateLiquidity(position, args.quoteAmount),
+    ...validateBorrowUndercollateralized(targetPosition, position, args.quoteAmount),
   ]
 
   return {

--- a/packages/dma-library/src/strategies/morphoblue/borrow/open.ts
+++ b/packages/dma-library/src/strategies/morphoblue/borrow/open.ts
@@ -113,13 +113,8 @@ export const open: MorphoOpenBorrowStrategy = async (args, dependencies) => {
   const warnings = [...validateGenerateCloseToMaxLtv(targetPosition, position)]
 
   const errors = [
-    ...validateLiquidity(position, args.quoteAmount, args.quotePrecision),
-    ...validateBorrowUndercollateralized(
-      targetPosition,
-      position,
-      args.quoteAmount,
-      args.quotePrecision,
-    ),
+    ...validateLiquidity(position, args.quoteAmount),
+    ...validateBorrowUndercollateralized(targetPosition, position, args.quoteAmount),
   ]
 
   return {

--- a/packages/dma-library/src/strategies/morphoblue/borrow/payback-withdraw.ts
+++ b/packages/dma-library/src/strategies/morphoblue/borrow/payback-withdraw.ts
@@ -93,7 +93,7 @@ export const paybackWithdraw: MorphoPaybackWithdrawStrategy = async (args, depen
   const warnings = [...validateWithdrawCloseToMaxLtv(targetPosition, position)]
 
   const errors = [
-    ...validateBorrowUndercollateralized(targetPosition, position, ZERO, args.quotePrecision),
+    ...validateBorrowUndercollateralized(targetPosition, position, ZERO),
     ...validateOverRepay(position, args.quoteAmount),
   ]
 

--- a/packages/dma-library/src/strategies/morphoblue/validation/validateBorrowUndercollateralized.ts
+++ b/packages/dma-library/src/strategies/morphoblue/validation/validateBorrowUndercollateralized.ts
@@ -7,9 +7,8 @@ export function validateBorrowUndercollateralized(
   position: MorphoBluePosition,
   targetPosition: MorphoBluePosition,
   borrowAmount: BigNumber,
-  quotePrecision: number,
 ): AjnaError[] {
-  if (validateLiquidity(position, borrowAmount, quotePrecision).length > 0) {
+  if (validateLiquidity(position, borrowAmount).length > 0) {
     return []
   }
 

--- a/packages/dma-library/src/strategies/morphoblue/validation/validateLiquidity.ts
+++ b/packages/dma-library/src/strategies/morphoblue/validation/validateLiquidity.ts
@@ -5,12 +5,14 @@ export function validateLiquidity(
   position: MorphoBluePosition,
   borrowAmount: BigNumber,
 ): AjnaError[] {
-  if (position.market.totalSupplyAssets.minus(position.market.totalBorrowAssets).lt(borrowAmount)) {
+  const liquidity = position.market.totalSupplyAssets.minus(position.market.totalBorrowAssets)
+
+  if (liquidity.lt(borrowAmount)) {
     return [
       {
         name: 'not-enough-liquidity',
         data: {
-          amount: borrowAmount.toString(),
+          amount: liquidity.toString(),
         },
       },
     ]

--- a/packages/dma-library/src/strategies/morphoblue/validation/validateLiquidity.ts
+++ b/packages/dma-library/src/strategies/morphoblue/validation/validateLiquidity.ts
@@ -1,16 +1,11 @@
-import { amountFromWei } from '@dma-common/utils/common'
 import { AjnaError, MorphoBluePosition } from '@dma-library/types'
 import { BigNumber } from 'bignumber.js'
 
 export function validateLiquidity(
   position: MorphoBluePosition,
   borrowAmount: BigNumber,
-  quotePrecision: number,
 ): AjnaError[] {
-  const totalSupplyAssets = amountFromWei(position.market.totalSupplyAssets, quotePrecision)
-  const totalBorrowAssets = amountFromWei(position.market.totalBorrowAssets, quotePrecision)
-
-  if (totalSupplyAssets.minus(totalBorrowAssets).lt(borrowAmount)) {
+  if (position.market.totalSupplyAssets.minus(position.market.totalBorrowAssets).lt(borrowAmount)) {
     return [
       {
         name: 'not-enough-liquidity',

--- a/packages/dma-library/src/types/morphoblue/morphoblue-position.ts
+++ b/packages/dma-library/src/types/morphoblue/morphoblue-position.ts
@@ -1,5 +1,5 @@
 import { Address } from '@deploy-configurations/types/address'
-import { ZERO } from '@dma-common/constants'
+import { ONE, ZERO } from '@dma-common/constants'
 import { negativeToZero, normalizeValue } from '@dma-common/utils/common'
 import { IRiskRatio, RiskRatio } from '@domain'
 import { BigNumber } from 'bignumber.js'
@@ -75,7 +75,7 @@ export class MorphoBluePosition implements LendingPosition {
 
   get liquidationPrice() {
     return normalizeValue(
-      this.collateralAmount.times(this.maxRiskRatio.loanToValue).div(this.debtAmount),
+      ONE.div(this.collateralAmount.times(this.maxRiskRatio.loanToValue).div(this.debtAmount)),
     )
   }
 

--- a/packages/dma-library/src/views/morpho/index.ts
+++ b/packages/dma-library/src/views/morpho/index.ts
@@ -68,9 +68,13 @@ export async function getMorphoPosition(
   const positionParams = await morpho.position(marketId, proxyAddress)
 
   const totals = {
-    totalSupplyAssets: new BigNumber(market.totalSupplyAssets.toString()).div(TEN.pow(18)),
+    totalSupplyAssets: new BigNumber(market.totalSupplyAssets.toString()).div(
+      TEN.pow(quotePrecision),
+    ),
     totalSupplyShares: new BigNumber(market.totalSupplyShares.toString()).div(TEN.pow(24)),
-    totalBorrowAssets: new BigNumber(market.totalBorrowAssets.toString()).div(TEN.pow(18)),
+    totalBorrowAssets: new BigNumber(market.totalBorrowAssets.toString()).div(
+      TEN.pow(quotePrecision),
+    ),
     totalBorrowShares: new BigNumber(market.totalBorrowShares.toString()).div(TEN.pow(24)),
   }
 


### PR DESCRIPTION
## [Fix totalSupplyAssets and totalBorrowAssets](https://app.shortcut.com/oazo-apps/story/13864/library-incorrectly-says-that-there-is-not-enough-liquidity-for-wsteth-usdc-market)

## Description of Changes

Please list the changes introduced by this PR:

- Used `quotePrecission` to parse values of `totalSupplyAssets` and `totalBorrowAssets`.
- Removed previously added passing `quotePrecission` to validation methods.
- Courtesy of @piekczyk; update `liquidationPrice` calculation.