### PR TITLE
Ajna dust limit validation adjustment

### DIFF
--- a/packages/dma-library/package.json
+++ b/packages/dma-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oasisdex/dma-library",
-  "version": "0.6.12",
+  "version": "0.6.13",
   "typings": "lib/index.d.ts",
   "types": "lib/index.d.ts",
   "main": "lib/index.js",

--- a/packages/dma-library/src/protocols/ajna/utils.ts
+++ b/packages/dma-library/src/protocols/ajna/utils.ts
@@ -11,7 +11,7 @@ import {
   getPoolLiquidity,
   getTotalPoolLiquidity,
 } from '@dma-library/strategies/ajna/validation/borrowish/notEnoughLiquidity'
-import { SwapData } from '@dma-library/types'
+import { AjnaPosition, SwapData } from '@dma-library/types'
 import {
   AjnaCommonDependencies,
   AjnaCommonDMADependencies,
@@ -521,4 +521,12 @@ export function getAjnaEarnDepositFee({
   return simulationPrice?.lt(positionPrice) || simulationQuoteAmount?.gt(positionQuoteAmount)
     ? simulationQuoteAmount?.times(depositFeeRate)
     : undefined
+}
+
+export function shouldDisplayAjnaDustLimitValidation(position: AjnaPosition) {
+  return (
+    position.pool.loansCount.gt(10) &&
+    position.debtAmount.lt(position.pool.poolMinDebtAmount) &&
+    position.debtAmount.gt(0)
+  )
 }

--- a/packages/dma-library/src/strategies/ajna/validation/borrowish/dustLimit.ts
+++ b/packages/dma-library/src/strategies/ajna/validation/borrowish/dustLimit.ts
@@ -1,8 +1,9 @@
 import { formatCryptoBalance } from '@dma-common/utils/common/formaters'
+import { shouldDisplayAjnaDustLimitValidation } from '@dma-library/protocols/ajna'
 import { AjnaError, AjnaPosition } from '@dma-library/types/ajna'
 
 export function validateDustLimit(position: AjnaPosition): AjnaError[] {
-  if (position.debtAmount.lt(position.pool.poolMinDebtAmount) && position.debtAmount.gt(0)) {
+  if (shouldDisplayAjnaDustLimitValidation(position)) {
     return [
       {
         name: 'debt-less-then-dust-limit',

--- a/packages/dma-library/src/strategies/ajna/validation/multiply/dustLimit.ts
+++ b/packages/dma-library/src/strategies/ajna/validation/multiply/dustLimit.ts
@@ -1,14 +1,11 @@
-import { formatCryptoBalance } from '@dma-common/utils/common/formaters'
+import { shouldDisplayAjnaDustLimitValidation } from '@dma-library/protocols/ajna'
 import { AjnaError, AjnaPosition } from '@dma-library/types/ajna'
 
 export function validateDustLimitMultiply(position: AjnaPosition): AjnaError[] {
-  if (position.debtAmount.lt(position.pool.poolMinDebtAmount) && position.debtAmount.gt(0)) {
+  if (shouldDisplayAjnaDustLimitValidation(position)) {
     return [
       {
         name: 'debt-less-then-dust-limit-multiply',
-        data: {
-          minDebtAmount: formatCryptoBalance(position.pool.poolMinDebtAmount),
-        },
       },
     ]
   } else {

--- a/packages/dma-library/src/types/ajna/ajna-position.ts
+++ b/packages/dma-library/src/types/ajna/ajna-position.ts
@@ -114,9 +114,9 @@ export class AjnaPosition implements LendingPosition {
   }
 
   get minRiskRatio() {
-    const loanToValue = this.pool.poolMinDebtAmount.div(
-      this.collateralAmount.times(this.collateralPrice),
-    )
+    const loanToValue = this.pool.loansCount.gt(10)
+      ? this.pool.poolMinDebtAmount.div(this.collateralAmount.times(this.collateralPrice))
+      : ZERO
 
     return new RiskRatio(normalizeValue(loanToValue), RiskRatio.TYPE.LTV)
   }

--- a/packages/dma-library/src/types/ajna/ajna-validations.ts
+++ b/packages/dma-library/src/types/ajna/ajna-validations.ts
@@ -21,9 +21,6 @@ export type AjnaErrorDustLimit = {
 
 export type AjnaErrorDustLimitMultiply = {
   name: 'debt-less-then-dust-limit-multiply'
-  data: {
-    minDebtAmount: string
-  }
 }
 
 export type AjnaErrorWithdrawMoreThanAvailable = {


### PR DESCRIPTION
## [Ajna dust limit validation adjustment](https://app.shortcut.com/oazo-apps/story/14176/bug-ajna-no-check-for-first-10-loans-when-using-mindebtamount-which-blocks-users-from-opening-new-positions)

Please provide a link to the ticket:

## Description of Changes

Please list the changes introduced by this PR:

- adjusted dust limit condition so it takes into account number of loans

## How to Test

Please provide instructions on how to test the changes in this PR:

## PR Definition of Done

Please ensure the following requirements have been met before marking the PR as ready for review:

- [ ] All checks are passing
- [ ] PR is linked to a corresponding ticket
- [ ] PR title is clear and concise
- [ ] Code has been self-reviewed and any fixes or improvements noted (See Code review standards in Notion)
- [ ] Documentation has been updated if necessary
