### PR TITLE
🐛 Aave/Spark: Fix close to debt with WBTC as collateral

### DIFF
--- a/packages/dma-library/package.json
+++ b/packages/dma-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oasisdex/dma-library",
-  "version": "0.6.26-rc.1",
+  "version": "0.6.26",
   "typings": "lib/index.d.ts",
   "types": "lib/index.d.ts",
   "main": "lib/index.js",

--- a/packages/dma-library/package.json
+++ b/packages/dma-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oasisdex/dma-library",
-  "version": "0.6.25",
+  "version": "0.6.26-rc.1",
   "typings": "lib/index.d.ts",
   "types": "lib/index.d.ts",
   "main": "lib/index.js",

--- a/packages/dma-library/src/operations/aave/multiply/v3/close.ts
+++ b/packages/dma-library/src/operations/aave/multiply/v3/close.ts
@@ -69,14 +69,14 @@ export const close: AaveV3CloseOperation = async ({
 
   const withdrawCollateralFromAAVE = actions.aave.v3.aaveV3Withdraw(network, {
     asset: collateral.address,
-    amount: collateralAmountToBeSwapped,
+    amount: collateralAmountToBeSwapped.minus(1),
     to: proxy.address,
   })
 
   const swapCollateralTokensForDebtTokens = actions.common.swap(network, {
     fromAsset: collateral.address,
     toAsset: debt.address,
-    amount: collateralAmountToBeSwapped || ZERO,
+    amount: collateralAmountToBeSwapped.minus(1) || ZERO,
     receiveAtLeast: swap.receiveAtLeast,
     fee: swap.fee,
     withData: swap.data,

--- a/packages/dma-library/src/strategies/aave-like/multiply/close/close.ts
+++ b/packages/dma-library/src/strategies/aave-like/multiply/close/close.ts
@@ -128,7 +128,7 @@ async function getAaveSwapDataToCloseToDebt(
     addresses,
   )
 
-  const swapAmountBeforeFees = dependencies.currentPosition.collateral.amount
+  const swapAmountBeforeFees = dependencies.currentPosition.collateral.amount.minus(1)
   const fromToken = {
     ...collateralToken,
     precision: collateralToken.precision || TYPICAL_PRECISION,


### PR DESCRIPTION
## Ticket URL
[Shortcut Ticket](https://app.shortcut.com/oazo-apps/story/14372/aave-close-to-debt-with-wbtc)

## Description of Changes
- When we close our position we perform 3 withdraws. First for swap, second for payback flashloan and 3th for return rest of funds to user. 
- When we close the position to the debt token in the first withdrawal, we get all collateral to swap it for debt, so there shouldn't be more in the position for the third withdrawal. Considering the time that has passed from the creation of calldata to the transaction, the balance of `AToken` will increase. Therefore, we can withdraw a small amount. But WBTC has only 8 decimals, so even if we earn something, we won't see it.
- The fix is somewhat hacky. We need to ensure that we have something to withdraw in the last step. Therefore, we decrease the initial amount by 1 unit to guarantee that we will have 1 unit available for withdrawal.

[Failed Transaction](https://dashboard.tenderly.co/explorer/fork/4dd5668d-805f-42e1-9234-91116bd65452/simulation/7922b21a-ba22-4002-b398-6ce1df250791)
[Success Transaction](https://dashboard.tenderly.co/explorer/fork/4dd5668d-805f-42e1-9234-91116bd65452/simulation/650b2a70-214c-421a-bec2-ad0bb273987e)
