### PR TITLE
feat: add support for raw TX in multisig validation

### DIFF
--- a/packages/dma-contracts/tasks/common/decodedCalldata.ts
+++ b/packages/dma-contracts/tasks/common/decodedCalldata.ts
@@ -1,0 +1,65 @@
+import { ethers } from 'ethers'
+
+export type DecodedParameter = {
+  name: string
+  type: string
+  value: any
+}
+
+export type DecodedCalldata = {
+  method: string
+  parameters: DecodedParameter[]
+}
+
+export type FunctionInputs = {
+  name: string
+  type: string
+}
+
+export type FunctionSignature = {
+  name: string
+  inputs: FunctionInputs[]
+}
+
+export type FunctionSignaturesMap = Record<string, FunctionSignature>
+
+export function tryDecodeCallData(
+  functionSignature: FunctionSignature,
+  calldata: string,
+): DecodedCalldata | undefined {
+  const paramTypes = functionSignature.inputs.map(input => input.type)
+  const paramNames = functionSignature.inputs.map(input => input.name)
+  const inputFunctionSelector = calldata.slice(0, 10)
+  const inputParamsData = `0x${calldata.slice(10)}`
+
+  const signature = getStringSignature(functionSignature.name, paramTypes)
+  const functionSelector = ethers.utils.keccak256(ethers.utils.toUtf8Bytes(signature)).slice(0, 10)
+
+  if (inputFunctionSelector !== functionSelector) {
+    return undefined
+  }
+
+  const abiCoder = ethers.utils.defaultAbiCoder
+  const decodedData = abiCoder.decode(paramTypes, inputParamsData)
+
+  if (decodedData.length !== paramNames.length) {
+    return undefined
+  }
+
+  const decodedParams = decodedData.map((value, index): DecodedParameter => {
+    return {
+      name: paramNames[index],
+      type: paramTypes[index],
+      value,
+    }
+  })
+
+  return {
+    method: functionSignature.name,
+    parameters: decodedParams,
+  }
+}
+
+export function getStringSignature(functionName: string, parameters: string[]): string {
+  return `${functionName}(${parameters.join(',')})`
+}

--- a/packages/dma-contracts/tasks/common/operations-utils.ts
+++ b/packages/dma-contracts/tasks/common/operations-utils.ts
@@ -3,6 +3,7 @@ import * as OperationGetters from '@deploy-configurations/operation-definitions'
 import { Network } from '@deploy-configurations/types/network'
 import { ethers } from 'ethers'
 
+import { FunctionSignaturesMap } from './decodedCalldata'
 import { ActionDefinition } from './verification-utils'
 
 export type OperationDefinition = {
@@ -15,6 +16,18 @@ export type OperationDefinitionMaybe = OperationDefinition | undefined
 export type OperationDefinitionGetter = (string) => OperationDefinition
 
 export class OperationsDatabase {
+  public static readonly functions: FunctionSignaturesMap = {
+    addOperation: {
+      name: 'addOperation',
+      inputs: [
+        {
+          name: 'operation',
+          type: '(bytes32[],bool[],string)',
+        },
+      ],
+    },
+  }
+
   private readonly opNameToDefinition: { [key: string]: OperationDefinition } = {}
   private readonly opNameToCalldata: { [key: string]: string } = {}
 

--- a/packages/dma-contracts/tasks/common/system-utils.ts
+++ b/packages/dma-contracts/tasks/common/system-utils.ts
@@ -5,6 +5,7 @@ import { Network } from '@deploy-configurations/types/network'
 import { ethers } from 'ethers'
 
 import { loadContractNames } from '../../../deploy-configurations/constants/load-contract-names'
+import { FunctionSignaturesMap } from './decodedCalldata'
 
 export type SystemEntry = SystemConfigEntry & {
   path: string
@@ -16,7 +17,23 @@ export type ServiceNameEntry = {
   entryNameHash: string
   path: string
 }
+
 export class SystemDatabase {
+  public static readonly functions: FunctionSignaturesMap = {
+    addNamedService: {
+      name: 'addNamedService',
+      inputs: [
+        {
+          name: 'serviceNameHash',
+          type: 'bytes32',
+        },
+        {
+          name: 'serviceAddress',
+          type: 'address',
+        },
+      ],
+    },
+  }
   private readonly systemEntries: SystemEntry[] = []
   private readonly contractAddressToEntry: { [key: string]: SystemEntry } = {}
 

--- a/packages/dma-contracts/tasks/validate-multisig-tx/decoders.ts
+++ b/packages/dma-contracts/tasks/validate-multisig-tx/decoders.ts
@@ -18,6 +18,7 @@ export function decodeExecutionData(
   const systemDatabase = new SystemDatabase(network)
 
   return executionData.map(execution => {
+    console.log('execution', JSON.stringify(execution, null, 2))
     const entry = systemDatabase.getEntryByAddress(execution.to.address)
 
     execution.to.name = entry?.name

--- a/packages/dma-contracts/tasks/validate-multisig-tx/safe-utils.ts
+++ b/packages/dma-contracts/tasks/validate-multisig-tx/safe-utils.ts
@@ -1,4 +1,3 @@
-import { Network } from '@dma-contracts/../dma-library/src'
 import SafeApiKit from '@safe-global/api-kit'
 import { EthersAdapter } from '@safe-global/protocol-kit'
 import { EthAdapter, SafeMultisigTransactionResponse } from '@safe-global/safe-core-sdk-types'


### PR DESCRIPTION
Added support for decoding raw transactions from Gnosis multisig. In Optimism, for some reason, the TXs do not have proper metadata coming from the contracts ABI, which makes the multisig validation tool fail.

In order to alleviate that, the tool now tries to infer the contract call from the raw calldata. Only 2 calls are supported:
- ServiceRegistry.addNamedService
- OperationsRegistry.addOperation

I tried to do it in a way that should make it easier to expand in the future. The tool could also use the target contract as a hint of which contract it needs to decode for. At the moment it brute forces the decoding until it finds a match or bails out if t doesn't find it.