### PR TITLE
chore: add new `0.02%` fee tier for certain token pairs

### DIFF
--- a/packages/dma-common/constants/fee.ts
+++ b/packages/dma-common/constants/fee.ts
@@ -1,6 +1,7 @@
 import { BigNumber } from 'bignumber.js'
 
 export const NO_FEE = 0
+export const LOW_CORRELATED_ASSET_FEE = 2
 export const REDUCED_FEE = 7
 export const DEFAULT_FEE = 20
 export const FEE_BASE = 10000

--- a/packages/dma-common/constants/index.ts
+++ b/packages/dma-common/constants/index.ts
@@ -1,5 +1,12 @@
 export { EMPTY_ADDRESS, NULL_ADDRESS } from './addresses'
-export { DEFAULT_FEE, FEE_BASE, FEE_ESTIMATE_INFLATOR, NO_FEE, REDUCED_FEE } from './fee'
+export {
+  DEFAULT_FEE,
+  FEE_BASE,
+  FEE_ESTIMATE_INFLATOR,
+  LOW_CORRELATED_ASSET_FEE,
+  NO_FEE,
+  REDUCED_FEE,
+} from './fee'
 export {
   BILLION,
   FIFTY,

--- a/packages/dma-library/test/fee-resolver.test.ts
+++ b/packages/dma-library/test/fee-resolver.test.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_FEE, NO_FEE } from '@dma-common/constants'
+import { DEFAULT_FEE, LOW_CORRELATED_ASSET_FEE, NO_FEE } from '@dma-common/constants'
 import { feeResolver } from '@dma-library/utils/swap'
 import { isCorrelatedPosition } from '@dma-library/utils/swap/fee-resolver'
 import BigNumber from 'bignumber.js'
@@ -9,7 +9,10 @@ describe('feeResolver', function () {
     const fee = feeResolver('WSTETH', 'ETH', { isEntrySwap: true })
     assert(fee.isEqualTo(new BigNumber(DEFAULT_FEE)))
   })
-
+  it('should return LOW_CORRELATED_ASSET_FEE  for DAI and SUSDE', function () {
+    const fee = feeResolver('SUSDE', 'DAI', { isEntrySwap: false })
+    assert(fee.isEqualTo(new BigNumber(LOW_CORRELATED_ASSET_FEE)))
+  })
   it('should return NO_FEE when decreasing risk and token pair are correlated', function () {
     const fee = feeResolver('WSTETH', 'ETH')
     assert(fee.isEqualTo(new BigNumber(NO_FEE)))


### PR DESCRIPTION
## Ticket URL

Please provide a link to the ticket:

## Description of Changes

Please list the changes introduced by this PR:
 - add new `0.02%` fee tier for swaps between : 'USDE', 'SUSDE', 'DAI', 'USDC', 'USDT'

## How to Test

Please provide instructions on how to test the changes in this PR:

## PR Definition of Done

Please ensure the following requirements have been met before marking the PR as ready for review:

- [ ] All checks are passing
- [ ] PR is linked to a corresponding ticket
- [ ] PR title is clear and concise
- [ ] Code has been self-reviewed and any fixes or improvements noted (See Code review standards in Notion)
- [ ] Documentation has been updated if necessary
