### PR TITLE
chore: [sc-14853] Update adresses of DS Proxy Registry

### DIFF
--- a/packages/addresses/package.json
+++ b/packages/addresses/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oasisdex/addresses",
-  "version": "0.1.51",
+  "version": "0.1.52-rc.1",
   "typings": "lib/index.d.ts",
   "types": "lib/index.d.ts",
   "main": "lib/index.js",

--- a/packages/addresses/package.json
+++ b/packages/addresses/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oasisdex/addresses",
-  "version": "0.1.52-rc.1",
+  "version": "0.1.52",
   "typings": "lib/index.d.ts",
   "types": "lib/index.d.ts",
   "main": "lib/index.js",

--- a/packages/deploy-configurations/configs/arbitrum.conf.ts
+++ b/packages/deploy-configurations/configs/arbitrum.conf.ts
@@ -51,7 +51,7 @@ export const config: SystemConfig = {
       DSProxyRegistry: {
         name: 'DSProxyRegistry',
         deploy: false,
-        address: '0x9319710C25cdaDDD1766F0bDE40F1A4034C17c7e',
+        address: '0x283Cc5C26e53D66ed2Ea252D986F094B37E6e895',
         serviceRegistryName: SERVICE_REGISTRY_NAMES.common.DS_PROXY_REGISTRY,
         history: [],
         constructorArgs: ['address:DSProxyFactory'],

--- a/packages/deploy-configurations/configs/base.conf.ts
+++ b/packages/deploy-configurations/configs/base.conf.ts
@@ -51,7 +51,7 @@ export const config: SystemConfig = {
       DSProxyRegistry: {
         name: 'DSProxyRegistry',
         deploy: false,
-        address: '0x29CCc2C12054Ae0A5eE6FE5120784D33ec17B7E9',
+        address: '0x425fA97285965E01Cc5F951B62A51F6CDEA5cc0d',
         serviceRegistryName: SERVICE_REGISTRY_NAMES.common.DS_PROXY_REGISTRY,
         history: [],
         constructorArgs: ['address:DSProxyFactory'],

--- a/packages/deploy-configurations/configs/optimism.conf.ts
+++ b/packages/deploy-configurations/configs/optimism.conf.ts
@@ -52,7 +52,7 @@ export const config: SystemConfig = {
       DSProxyRegistry: {
         name: 'DSProxyRegistry',
         deploy: false,
-        address: '0x4EcDc277484D71A3BD15f36C858aEc2C56803869',
+        address: '0x283Cc5C26e53D66ed2Ea252D986F094B37E6e895',
         serviceRegistryName: SERVICE_REGISTRY_NAMES.common.DS_PROXY_REGISTRY,
         history: [],
         constructorArgs: ['address:DSProxyFactory'],

--- a/packages/deploy-configurations/configs/sepolia.conf.ts
+++ b/packages/deploy-configurations/configs/sepolia.conf.ts
@@ -44,7 +44,7 @@ export const config: SystemConfig = {
       DSProxyFactory: {
         name: 'DSProxyFactory',
         deploy: false,
-        address: '0x84eFB9c18059394172D0d69A3E58B03320001871',
+        address: '0x0000000000000000000000000000000000000000',
         serviceRegistryName: SERVICE_REGISTRY_NAMES.common.DS_PROXY_FACTORY,
         history: [],
         constructorArgs: [],
@@ -52,7 +52,7 @@ export const config: SystemConfig = {
       DSProxyRegistry: {
         name: 'DSProxyRegistry',
         deploy: false,
-        address: '0x46759093D8158db8BB555aC7C6F98070c56169ce',
+        address: '0x0000000000000000000000000000000000000000',
         serviceRegistryName: SERVICE_REGISTRY_NAMES.common.DS_PROXY_REGISTRY,
         history: [],
         constructorArgs: ['address:DSProxyFactory'],


### PR DESCRIPTION
Story details: https://app.shortcut.com/oazo-apps/story/14853

The contract addresses for DSProxyRegistry and DSProxyFactory in several configuration files were updated. These changes impact optimism.conf.ts, base.conf.ts, sepolia.conf.ts, and arbitrum.conf.ts, signifying important changes to the locations of these contracts.
