### PR TITLE
chore: use feeresolver in erc4626

### DIFF
--- a/packages/dma-library/package.json
+++ b/packages/dma-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oasisdex/dma-library",
-  "version": "0.6.47",
+  "version": "0.6.48",
   "typings": "lib/index.d.ts",
   "types": "lib/index.d.ts",
   "main": "lib/index.js",

--- a/packages/dma-library/src/strategies/common/erc4626/deposit.ts
+++ b/packages/dma-library/src/strategies/common/erc4626/deposit.ts
@@ -3,7 +3,6 @@ import { amountToWei } from '@dma-common/utils/common'
 import { operations } from '@dma-library/operations'
 import { getGenericSwapData } from '@dma-library/strategies/common'
 import { encodeOperation } from '@dma-library/utils/operation'
-import { isCorrelatedPosition } from '@dma-library/utils/swap'
 import { views } from '@dma-library/views'
 import BigNumber from 'bignumber.js'
 import { ethers } from 'ethers'
@@ -171,9 +170,5 @@ async function getSwapData(args: Erc4626DepositPayload, dependencies: Erc4626Com
     slippage: args.slippage,
     swapAmountBeforeFees: swapAmountBeforeFees,
     getSwapData: dependencies.getSwapData,
-    // TODO: use fee resolver with low correlated fee
-    __feeOverride: isCorrelatedPosition(args.pullTokenSymbol, args.depositTokenSymbol)
-      ? new BigNumber(2)
-      : new BigNumber(20),
   })
 }

--- a/packages/dma-library/src/strategies/common/erc4626/withdraw.ts
+++ b/packages/dma-library/src/strategies/common/erc4626/withdraw.ts
@@ -3,7 +3,6 @@ import { amountToWei } from '@dma-common/utils/common'
 import { operations } from '@dma-library/operations'
 import { getGenericSwapData } from '@dma-library/strategies/common'
 import { encodeOperation } from '@dma-library/utils/operation'
-import { isCorrelatedPosition } from '@dma-library/utils/swap'
 import { views } from '@dma-library/views'
 import BigNumber from 'bignumber.js'
 
@@ -179,8 +178,5 @@ async function getSwapData(args: Erc4626WithdrawPayload, dependencies: Erc4626Co
     slippage: args.slippage,
     swapAmountBeforeFees: swapAmountBeforeFees,
     getSwapData: dependencies.getSwapData,
-    __feeOverride: isCorrelatedPosition(args.withdrawTokenSymbol, args.returnTokenSymbol)
-      ? new BigNumber(2)
-      : new BigNumber(20),
   })
 }


### PR DESCRIPTION
## Ticket URL

Please provide a link to the ticket:

## Description of Changes

Please list the changes introduced by this PR:

- remove fee override for correlated assets
- use `feeResolver` in `getGenericSwapData` insteead - https://github.com/OasisDEX/oasis-earn-sc/blob/23ea3a2ca0d50de949fade373354d1b9d6e14115/packages/dma-library/src/strategies/common/generic-swap-data.ts#L40
-  fee resolver will resolve to `0.02%` fee for the specified tokens : https://github.com/OasisDEX/oasis-earn-sc/blob/23ea3a2ca0d50de949fade373354d1b9d6e14115/packages/dma-library/src/utils/swap/fee-resolver.ts#L95

## How to Test

Please provide instructions on how to test the changes in this PR:

## PR Definition of Done

Please ensure the following requirements have been met before marking the PR as ready for review:

- [ ] All checks are passing
- [ ] PR is linked to a corresponding ticket
- [ ] PR title is clear and concise
- [ ] Code has been self-reviewed and any fixes or improvements noted (See Code review standards in Notion)
- [ ] Documentation has been updated if necessary
