### PR TITLE
fix: fix FL amounts for aave ops

### DIFF
--- a/packages/dma-library/package.json
+++ b/packages/dma-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oasisdex/dma-library",
-  "version": "0.6.76",
+  "version": "0.6.77",
   "typings": "lib/index.d.ts",
   "types": "lib/index.d.ts",
   "main": "lib/index.js",

--- a/packages/dma-library/src/strategies/aave-like/multiply/adjust/build-operation.ts
+++ b/packages/dma-library/src/strategies/aave-like/multiply/adjust/build-operation.ts
@@ -4,7 +4,7 @@ import { AdjustRiskDownArgs } from '@dma-library/operations/aave/multiply/v3/adj
 import { AdjustRiskUpArgs } from '@dma-library/operations/aave/multiply/v3/adjust-risk-up'
 import { resolveAaveLikeMultiplyOperations } from '@dma-library/operations/aave-like/resolve-aavelike-operations'
 import { getAaveTokenAddresses } from '@dma-library/strategies/aave/common'
-import { IOperation, SwapData } from '@dma-library/types'
+import { FlashloanProvider, IOperation, SwapData } from '@dma-library/types'
 import { resolveFlashloanProvider } from '@dma-library/utils/flashloan/resolve-provider'
 import { feeResolver } from '@dma-library/utils/swap'
 import * as Domain from '@domain'
@@ -146,8 +146,8 @@ export async function buildAdjustFlashloan(
     debtToken: args.debtToken.symbol,
     collateralToken: args.collateralToken.symbol,
   })
-
-  if (dependencies.protocolType === 'Spark') {
+  // We dont use the  if Spark condition since on L2s non Maker FLS are used for multiply operations
+  if (flashloanProvider !== FlashloanProvider.DssFlash) {
     // Need to add fees to the swap amount
     const fromSwapAmountBeforeFees = swap.fromTokenAmount.plus(preSwapFee)
     const receivedAmountAfterSwap = swap.minToTokenAmount

--- a/packages/dma-library/src/strategies/aave-like/multiply/close/build-operation.ts
+++ b/packages/dma-library/src/strategies/aave-like/multiply/close/build-operation.ts
@@ -3,7 +3,7 @@ import { FEE_BASE, ONE, TYPICAL_PRECISION } from '@dma-common/constants'
 import { amountFromWei, amountToWei } from '@dma-common/utils/common'
 import { resolveAaveLikeMultiplyOperations } from '@dma-library/operations/aave-like/resolve-aavelike-operations'
 import { SAFETY_MARGIN } from '@dma-library/strategies/aave-like/multiply/close/constants'
-import { IOperation, SwapData } from '@dma-library/types'
+import { FlashloanProvider, IOperation, SwapData } from '@dma-library/types'
 import { resolveFlashloanProvider } from '@dma-library/utils/flashloan/resolve-provider'
 import { feeResolver } from '@dma-library/utils/swap'
 import * as Domain from '@domain'
@@ -105,8 +105,8 @@ export async function buildCloseFlashloan(
     debtToken: args.debtToken.symbol,
     collateralToken: args.collateralToken.symbol,
   })
-
-  if (dependencies.protocolType === 'Spark') {
+  // We dont use the  if Spark condition since on L2s non Maker FLS are used for multiply operations
+  if (flashloanProvider !== FlashloanProvider.DssFlash) {
     // This covers off the situation where debt balances accrue interest
     const amountToFlashloan = dependencies.currentPosition.debt.amount.times(
       ONE.plus(SAFETY_MARGIN),


### PR DESCRIPTION

## Description of Changes

Please list the changes introduced by this PR:

- use debt amount as FL amount for non maker FL operations
- we used debt amount only for `Spark` but on L2s we use Balancer also for Aaave v3

## How to Test

Please provide instructions on how to test the changes in this PR:

## PR Definition of Done

Please ensure the following requirements have been met before marking the PR as ready for review:

- [ ] All checks are passing
- [ ] PR is linked to a corresponding ticket
- [ ] PR title is clear and concise
- [ ] Code has been self-reviewed and any fixes or improvements noted (See Code review standards in Notion)
- [ ] Documentation has been updated if necessary
